### PR TITLE
Create Python packages on generate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
           WORKSPACE_ROOT=$PWD
           cd /tmp/ && git clone https://github.com/alphauslabs/blue-sdk-go && cd blue-sdk-go
           cp -rv $WORKSPACE_ROOT/generated/go/* . && git status
+          find . -type d -exec touch {}/__init__.py \;
           git config user.email "dev@mobingi.com"
           git config user.name "mobingideployer"
           git add . && git commit -am "$GITHUB_REF $GITHUB_SHA" || true


### PR DESCRIPTION
All Python packages require an `__init__.py` in every directory for the interpreter to be able to "find" them. Therefore, we need every directory to include one of these files.