### PR TITLE
Undid a bad thing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
           WORKSPACE_ROOT=$PWD
           cd /tmp/ && git clone https://github.com/alphauslabs/blue-sdk-go && cd blue-sdk-go
           cp -rv $WORKSPACE_ROOT/generated/go/* . && git status
-          find . -type d -exec touch {}/__init__.py \;
           git config user.email "dev@mobingi.com"
           git config user.name "mobingideployer"
           git add . && git commit -am "$GITHUB_REF $GITHUB_SHA" || true


### PR DESCRIPTION
First of all, I put that line that generates `__init__.py` files under the wrong section so I might have to fix some stuff with the golang SDK. Secondly, I decided to move the Python SDK from traditional packages to namespace packages. My first thought was that traditional packages would be best because they support both Python 2 and Python 3 but, given the prevalence of Python 3, the fact that namespace package support has been added to Python 2 retrospectively, and the fact that protobuf produces a directory structure that is incompatible with traditional packages, I made the decision to revert this change altogether.