### PR TITLE
Fix python iris

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           git push --set-upstream origin-tmp
           # Update blue-sdk-python:
           cd /tmp/ && git clone https://github.com/alphauslabs/blue-sdk-python && cd blue-sdk-python/alphausblue
-          cp -rv $WORKSPACE_ROOT/generated/py/* . && git status
+          cp -rv $WORKSPACE_ROOT/generated/py/alphausblue* . && git status
           git config user.email "dev@mobingi.com"
           git config user.name "mobingideployer"
           git add . && git commit -am "$GITHUB_REF $GITHUB_SHA" || true

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 echo "Compiling proto files..." && buf generate
 
 # Compile services for blue-sdk-python; with grpc.
+mkdir -p ./generated/py
 python3 -m grpc_tools.protoc -I . --python_out=./generated/py --grpc_python_out=./generated/py \
         ./org/v1/*.proto \
         ./kvstore/v1/*.proto \

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -514,7 +514,21 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1UpdateRoleRequest"
+              "type": "object",
+              "properties": {
+                "newName": {
+                  "type": "string",
+                  "description": "Optional. If set, update the current name to this."
+                },
+                "permissions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Required. The list of permissions to attach to this role."
+                }
+              },
+              "description": "Request message for the Iam.UpdateRole rpc."
             }
           }
         ],
@@ -912,7 +926,8 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1CancelOperationRequest"
+              "type": "object",
+              "description": "Request message for the Operations.CancelOperation rpc."
             }
           }
         ],
@@ -1474,7 +1489,26 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1CreateAccountRequest"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Required. The account id to register."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Optional. If empty, set to the value of `id`."
+                },
+                "parent": {
+                  "type": "string",
+                  "description": "Optional. The parent `billingInternalId` of the billing group to which this account\nwill belong to."
+                },
+                "awsOptions": {
+                  "$ref": "#/definitions/v1CreateAccountRequestAwsOptions",
+                  "description": "Required for the `aws` vendor. AWS-specific options."
+                }
+              },
+              "description": "Request message for the Cost.CreateAccount rpc."
             }
           }
         ],
@@ -1599,7 +1633,30 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ReadAdjustmentsRequest"
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string",
+                  "description": "Optional. At the moment, only billing internal ids are supported. If set, reads the\nnon-usage-based adjustment details of this group. Valid only if `accountId` is not set.\nIf both `groupId` and `accountId` are not set, reads the adjustment details of the whole\norganization. Only valid for Ripple users. Implied (or discarded) for Wave(Pro) users."
+                },
+                "accountId": {
+                  "type": "string",
+                  "description": "Optional. If set, reads the non-usaged-based adjustment details of this account. Also\ninvalidates the `billingInternalId` value even if set. If both `billingInternalId`\nand `accountId` are not set, reads the adjustment details of the whole organization."
+                },
+                "startTime": {
+                  "type": "string",
+                  "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: `yyyymmdd`."
+                },
+                "endTime": {
+                  "type": "string",
+                  "description": "Optional. The UTC date to end the streaming data. If not set, current date will be\nused. Format: `yyyymmdd`."
+                },
+                "awsOptions": {
+                  "$ref": "#/definitions/v1ReadAdjustmentsRequestAwsOptions",
+                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+                }
+              },
+              "description": "Request message for the Cost.ReadAdjustments rpc."
             }
           }
         ],
@@ -1683,7 +1740,13 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1UpdateAccountBudgetRequest"
+              "type": "object",
+              "properties": {
+                "data": {
+                  "$ref": "#/definitions/apiBudget"
+                }
+              },
+              "title": "Request message for UpdateAccountBudget"
             }
           }
         ],
@@ -1788,7 +1851,13 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1CreateAccountBudgetRequest"
+              "type": "object",
+              "properties": {
+                "data": {
+                  "$ref": "#/definitions/apiBudget"
+                }
+              },
+              "title": "Request message for CreateAccountBudget"
             }
           }
         ],
@@ -1938,7 +2007,22 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1CalculateCostsRequest"
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string",
+                  "description": "Optional. If set to a particular billing group, calculate for that billing group.\nIf empty, calculate for all billing groups.\n\nAt the moment, for AWS, this is only valid for account type billing groups, not\ntag billing groups. If a tag billing group is provided, it is discarded and the\ncalculation is done for the whole organization."
+                },
+                "month": {
+                  "type": "string",
+                  "description": "Optional. The UTC month to calculate. If empty, it defaults to the previous month.\nFormat is `yyyymm`. For example, June 2021 will be `202106`."
+                },
+                "awsOptions": {
+                  "$ref": "#/definitions/v1CalculateCostsRequestAwsOptions",
+                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+                }
+              },
+              "description": "Request message for the Cost.CalculateCosts rpc."
             }
           }
         ],
@@ -1987,7 +2071,30 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ReadCostsRequest"
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string",
+                  "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple\nusers. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when\n`accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read\nthe usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
+                },
+                "accountId": {
+                  "type": "string",
+                  "description": "Optional. If set, reads the usage-based cost details of this account.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the\nusage-based cost details of the whole organization."
+                },
+                "startTime": {
+                  "type": "string",
+                  "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: yyyymmdd."
+                },
+                "endTime": {
+                  "type": "string",
+                  "description": "Optional. The UTC date to end the streaming data. If not set, current date will be\nused. Format: `yyyymmd`."
+                },
+                "awsOptions": {
+                  "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
+                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+                }
+              },
+              "description": "Request message for the Cost.ReadCosts rpc."
             }
           }
         ],
@@ -2269,7 +2376,26 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ReadNonTagCostsRequest"
+              "type": "object",
+              "properties": {
+                "billingInternalId": {
+                  "type": "string",
+                  "description": "Required. The billing internal id to stream."
+                },
+                "startTime": {
+                  "type": "string",
+                  "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: `yyyymmdd`."
+                },
+                "endTime": {
+                  "type": "string",
+                  "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used.\nFormat: `yyyymmdd`."
+                },
+                "groupByMonths": {
+                  "type": "boolean",
+                  "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`.\nIf not set, daily data will be returned."
+                }
+              },
+              "description": "Request message for the Cost.ReadNonTagCosts rpc."
             }
           }
         ],
@@ -2348,7 +2474,14 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1CreatePayerAccountRequest"
+              "type": "object",
+              "properties": {
+                "awsOptions": {
+                  "$ref": "#/definitions/v1CreatePayerAccountRequestAwsOptions",
+                  "description": "Required for the `aws` vendor. AWS-specific options."
+                }
+              },
+              "description": "Request message for the Cost.CreatePayerAccount rpc."
             }
           }
         ],
@@ -2526,7 +2659,21 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1GetRecommendationsRequest"
+              "type": "object",
+              "properties": {
+                "accounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Required. List of Account Ids."
+                },
+                "awsOptions": {
+                  "$ref": "#/definitions/v1GetRecommendationsRequestAwsOptions",
+                  "title": "Required if vendor = 'aws'"
+                }
+              },
+              "title": "Request message for GetRecommendations"
             }
           }
         ],
@@ -2573,7 +2720,40 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1GetCostReductionRequest"
+              "type": "object",
+              "properties": {
+                "reductionDisplay": {
+                  "type": "string",
+                  "title": "Required. Valid values: 'all', 'reservation', 'savingsplan'"
+                },
+                "period": {
+                  "type": "string",
+                  "description": "Optional. The month to display the cost reduction details. If not set,\nmonth-to-date will be used. Format: yyyymm."
+                },
+                "payerId": {
+                  "type": "string",
+                  "description": "Optional. Payer Id."
+                },
+                "groupId": {
+                  "type": "string",
+                  "description": "Optional. Billing group Id."
+                },
+                "accounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Optional. List of Account Ids."
+                },
+                "services": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Optional. List of services."
+                }
+              },
+              "title": "Request message for GetCostReduction"
             }
           }
         ],
@@ -2622,7 +2802,30 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ReadTagCostsRequest"
+              "type": "object",
+              "properties": {
+                "billingInternalId": {
+                  "type": "string",
+                  "description": "Required. The billing internal id to stream."
+                },
+                "startTime": {
+                  "type": "string",
+                  "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: `yyyymmdd`."
+                },
+                "endTime": {
+                  "type": "string",
+                  "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used.\nFormat: `yyyymmdd`."
+                },
+                "groupByMonths": {
+                  "type": "boolean",
+                  "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`.\nIf not set, daily data will be returned."
+                },
+                "awsOptions": {
+                  "$ref": "#/definitions/v1ReadTagCostsRequestAwsOptions",
+                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+                }
+              },
+              "description": "Request message for the Cost.ReadTagCosts rpc."
             }
           }
         ],
@@ -3470,17 +3673,13 @@
     "protobufAny": {
       "type": "object",
       "properties": {
-        "typeUrl": {
+        "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "Must be a valid serialized protocol buffer of the above specified type."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "rippleOrg": {
       "type": "object",
@@ -3549,28 +3748,6 @@
         }
       }
     },
-    "v1CalculateCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. If set to a particular billing group, calculate for that billing group.\nIf empty, calculate for all billing groups.\n\nAt the moment, for AWS, this is only valid for account type billing groups, not\ntag billing groups. If a tag billing group is provided, it is discarded and the\ncalculation is done for the whole organization."
-        },
-        "month": {
-          "type": "string",
-          "description": "Optional. The UTC month to calculate. If empty, it defaults to the previous month.\nFormat is `yyyymm`. For example, June 2021 will be `202106`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CalculateCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CalculateCosts rpc."
-    },
     "v1CalculateCostsRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -3588,16 +3765,6 @@
         }
       }
     },
-    "v1CancelOperationRequest": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the operation resource to be cancelled."
-        }
-      },
-      "description": "Request message for the Operations.CancelOperation rpc."
-    },
     "v1CostItem": {
       "type": "object",
       "properties": {
@@ -3606,27 +3773,6 @@
         }
       },
       "description": "Response message wrapper for cloud costs."
-    },
-    "v1CreateAccountBudgetRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "level": {
-          "type": "string",
-          "title": "Required. 'account' or 'acctgroup'"
-        },
-        "id": {
-          "type": "string",
-          "title": "Required. Account or AccountGroup Id"
-        },
-        "data": {
-          "$ref": "#/definitions/apiBudget"
-        }
-      },
-      "title": "Request message for CreateAccountBudget"
     },
     "v1CreateAccountBudgetResponse": {
       "type": "object",
@@ -3637,32 +3783,6 @@
         }
       },
       "title": "Response message for CreateAccountBudget"
-    },
-    "v1CreateAccountRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "id": {
-          "type": "string",
-          "description": "Required. The account id to register."
-        },
-        "name": {
-          "type": "string",
-          "description": "Optional. If empty, set to the value of `id`."
-        },
-        "parent": {
-          "type": "string",
-          "description": "Optional. The parent `billingInternalId` of the billing group to which this account\nwill belong to."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CreateAccountRequestAwsOptions",
-          "description": "Required for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CreateAccount rpc."
     },
     "v1CreateAccountRequestAwsOptions": {
       "type": "object",
@@ -3879,20 +3999,6 @@
       },
       "description": "Response message for the Organization.CreateOrg rpc."
     },
-    "v1CreatePayerAccountRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CreatePayerAccountRequestAwsOptions",
-          "description": "Required for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CreatePayerAccount rpc."
-    },
     "v1CreatePayerAccountRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -4052,50 +4158,6 @@
       },
       "description": "Response message for the Cost.GetCalculatorStatus rpc."
     },
-    "v1GetCostReductionRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "orgId": {
-          "type": "string",
-          "description": "Required. Organization Id."
-        },
-        "reductionDisplay": {
-          "type": "string",
-          "title": "Required. Valid values: 'all', 'reservation', 'savingsplan'"
-        },
-        "period": {
-          "type": "string",
-          "description": "Optional. The month to display the cost reduction details. If not set,\nmonth-to-date will be used. Format: yyyymm."
-        },
-        "payerId": {
-          "type": "string",
-          "description": "Optional. Payer Id."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. Billing group Id."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of Account Ids."
-        },
-        "services": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of services."
-        }
-      },
-      "title": "Request message for GetCostReduction"
-    },
     "v1GetCostReductionResponse": {
       "type": "object",
       "properties": {
@@ -4195,31 +4257,6 @@
         }
       },
       "description": "Response message for the Cost.GetPayerAccountImportHistory rpc."
-    },
-    "v1GetRecommendationsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "orgId": {
-          "type": "string",
-          "description": "Required. Organization Id."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. List of Account Ids."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1GetRecommendationsRequestAwsOptions",
-          "title": "Required if vendor = 'aws'"
-        }
-      },
-      "title": "Request message for GetRecommendations"
     },
     "v1GetRecommendationsRequestAwsOptions": {
       "type": "object",
@@ -4401,36 +4438,6 @@
     "v1Preference": {
       "type": "object"
     },
-    "v1ReadAdjustmentsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. At the moment, only billing internal ids are supported. If set, reads the\nnon-usage-based adjustment details of this group. Valid only if `accountId` is not set.\nIf both `groupId` and `accountId` are not set, reads the adjustment details of the whole\norganization. Only valid for Ripple users. Implied (or discarded) for Wave(Pro) users."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Optional. If set, reads the non-usaged-based adjustment details of this account. Also\ninvalidates the `billingInternalId` value even if set. If both `billingInternalId`\nand `accountId` are not set, reads the adjustment details of the whole organization."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: `yyyymmdd`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be\nused. Format: `yyyymmdd`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadAdjustmentsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadAdjustments rpc."
-    },
     "v1ReadAdjustmentsRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -4439,36 +4446,6 @@
           "description": "Optional. Set to US dollars (USD) by default (AWS CUR's default currency). You can\nset it to the desired three-letter currency symbol (i.e. JPY, EUR, GBP), in which\ncase, it will use the latest exchange rates provided by https://fixer.io. If you\nprefer a custom exchange rate, you can append the rate to the currency's three-letter\nsymbol. For example, `JPY:110.622` for the Japanese Yen. Note that the exchange rate\nshould be against the US dollar (USD)."
         }
       }
-    },
-    "v1ReadCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple\nusers. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when\n`accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read\nthe usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Optional. If set, reads the usage-based cost details of this account.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the\nusage-based cost details of the whole organization."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: yyyymmdd."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be\nused. Format: `yyyymmd`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadCosts rpc."
     },
     "v1ReadCostsRequestAwsOptions": {
       "type": "object",
@@ -4519,62 +4496,6 @@
       },
       "description": "A map of \"key:value\" column filters. Dependent on `groupByColumns` and/or `groupByMonth`.\nThe key indicates the column name while the value is the filter value prefixed by either\n\"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or\n\"!re:\" (reverse \"re:\"). Multiple map items will use the logical 'and' operator, e.g.\nmapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like to filter `productCode` to return only `AmazonEC2`, set to\n`{\"productCode\":\"eq:AmazonEC2\"}`. You can also use a regular expression like \n`{\"productCode\":\"re:AmazonEC2|AmazonRDS\"}`, which means return all AmazonEC2 or AmazonRDS\nlineitems. Or reverse regexp, such as `{\"productCode\":\"!re:^AmazonEC2$\"}`, which means\nreturn all items except `AmazonEC2`."
     },
-    "v1ReadNonTagCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Required. The billing internal id to stream."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: `yyyymmdd`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used.\nFormat: `yyyymmdd`."
-        },
-        "groupByMonths": {
-          "type": "boolean",
-          "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`.\nIf not set, daily data will be returned."
-        }
-      },
-      "description": "Request message for the Cost.ReadNonTagCosts rpc."
-    },
-    "v1ReadTagCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Required. The billing internal id to stream."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the\ncurrent month will be used. Format: `yyyymmdd`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used.\nFormat: `yyyymmdd`."
-        },
-        "groupByMonths": {
-          "type": "boolean",
-          "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`.\nIf not set, daily data will be returned."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadTagCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadTagCosts rpc."
-    },
     "v1ReadTagCostsRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -4583,23 +4504,6 @@
           "description": "Optional. If set, only return data for this tagId."
         }
       }
-    },
-    "v1UpdateAccountBudgetRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "budgetId": {
-          "type": "string",
-          "title": "Required. Budget Id"
-        },
-        "data": {
-          "$ref": "#/definitions/apiBudget"
-        }
-      },
-      "title": "Request message for UpdateAccountBudget"
     },
     "v1UpdateMetadataRequest": {
       "type": "object",
@@ -4624,31 +4528,6 @@
         }
       },
       "description": "Request message for the Organization.UpdatePassword rpc."
-    },
-    "v1UpdateRoleRequest": {
-      "type": "object",
-      "properties": {
-        "namespace": {
-          "type": "string",
-          "description": "Required. The new namespace."
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. The role name to update."
-        },
-        "newName": {
-          "type": "string",
-          "description": "Optional. If set, update the current name to this."
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. The list of permissions to attach to this role."
-        }
-      },
-      "description": "Request message for the Iam.UpdateRole rpc."
     },
     "v1UpdateUserRoleMappingRequest": {
       "type": "object",


### PR DESCRIPTION
This PR fixes an issue wherein all Python code that referenced the same package would use implicit relative imports, making it entirely incompatible with Python 3.