### PR TITLE
Fixed small issue with output of workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           git remote add origin-tmp https://$DEPLOYER_TOKEN@github.com/alphauslabs/blue-sdk-go.git > /dev/null 2>&1
           git push --set-upstream origin-tmp
           # Update blue-sdk-python:
-          cd /tmp/ && git clone https://github.com/alphauslabs/blue-sdk-python && cd blue-sdk-python/alphausblue
+          cd /tmp/ && git clone https://github.com/alphauslabs/blue-sdk-python && cd blue-sdk-python
           cp -rv $WORKSPACE_ROOT/generated/py/alphausblue* . && git status
           git config user.email "dev@mobingi.com"
           git config user.name "mobingideployer"


### PR DESCRIPTION
Currently, the workflow pushes all the code to `/alphausblue/alphausblue` in the Python SDK. This fixes that issue.