### PR TITLE
Removed aq_dashboard; I wish people would stop doing this to me

### DIFF
--- a/api/grouprootuser.proto
+++ b/api/grouprootuser.proto
@@ -142,27 +142,24 @@ message FeatureFlags {
   // Control access to sub-user management on Wave
   bool users_management = 26;
 
-  // Control access to the dashboard on Aqua
-  bool aq_dashboard = 27;
-
   // Control access to the Coverage Ratio pane on Aqua
-  bool aq_coverage_ratio = 28;
+  bool aq_coverage_ratio = 27;
 
   // Control access to the RI management pane on Aqua
-  bool aq_ri_management = 29;
+  bool aq_ri_management = 28;
 
   // Control access to the savings plan management pane on Aqua
-  bool aq_sp_management = 30;
+  bool aq_sp_management = 29;
 
   // Control access to RI and savings plan recommendations on Aqua
-  bool aq_ri_sp_instances = 31;
+  bool aq_ri_sp_instances = 30;
 
   // Control access to right-sizing on Aqua
-  bool aq_right_sizing = 32;
+  bool aq_right_sizing = 31;
 
   // Control access to scheduling on Aqua
-  bool aq_scheduling = 33;
+  bool aq_scheduling = 32;
 
   // Control access to the report filters pane in Wave Pro
-  bool report_filters = 34;
+  bool report_filters = 33;
 }


### PR DESCRIPTION
This PR removes the `aq_dashboard` field from the `FeatureFlags` definition because it was removed by Farhad from the API.