### PR TITLE
Added access-group support to cost requests and responses

### DIFF
--- a/api/coverage.proto
+++ b/api/coverage.proto
@@ -9,6 +9,9 @@ option java_outer_classname = "ApiCoverageProto";
 message OptionsData {
     string id = 1;
     repeated OptionsChart optionsChart = 2;
+    string company_id = 3;
+    string billinggroup_id = 4;
+    string billinggroup_name = 5;
 }
 
 message OptionsChart {
@@ -20,6 +23,9 @@ message OptionsChart {
 message OndemandData {
     string id = 1;
     repeated OndemandChart ondemandChart = 2;
+    string company_id = 3;
+    string billinggroup_id = 4;
+    string billinggroup_name = 5;
 }
 
 message OndemandChart {

--- a/api/coverage.proto
+++ b/api/coverage.proto
@@ -9,9 +9,8 @@ option java_outer_classname = "ApiCoverageProto";
 message OptionsData {
     string id = 1;
     repeated OptionsChart optionsChart = 2;
-    string company_id = 3;
-    string billinggroup_id = 4;
-    string billinggroup_name = 5;
+    string billinggroupId = 3;
+    string billinggroupName = 4;
 }
 
 message OptionsChart {
@@ -23,9 +22,8 @@ message OptionsChart {
 message OndemandData {
     string id = 1;
     repeated OndemandChart ondemandChart = 2;
-    string company_id = 3;
-    string billinggroup_id = 4;
-    string billinggroup_name = 5;
+    string billinggroupId = 3;
+    string billinggroupName = 4;
 }
 
 message OndemandChart {

--- a/api/utilization.proto
+++ b/api/utilization.proto
@@ -9,9 +9,8 @@ option java_outer_classname = "ApiUtilizationProto";
 message UtilizationData {
     string id = 1;
     repeated ChartData chartData = 2;
-    string company_id = 3;
-    string billinggroup_id = 4;
-    string billinggroup_name = 5;
+    string billinggroupId = 3;
+    string billinggroupName = 4;
 }
 
 message ChartData {

--- a/api/utilization.proto
+++ b/api/utilization.proto
@@ -9,6 +9,9 @@ option java_outer_classname = "ApiUtilizationProto";
 message UtilizationData {
     string id = 1;
     repeated ChartData chartData = 2;
+    string company_id = 3;
+    string billinggroup_id = 4;
+    string billinggroup_name = 5;
 }
 
 message ChartData {

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -1028,6 +1028,9 @@ message GetCostReductionRequest {
 
   // Optional. List of services.
   repeated string services = 11;
+
+  // Optional. Access group Id
+  string accessGroupId = 12;
 }
 
 // Response message for GetCostReduction
@@ -1063,6 +1066,9 @@ message GetUtilizationRequest {
 
   // Optional. Account group Id.
   string groupId = 8;
+
+  // Optional. Access group Id.
+  string accessGroupId = 9;
 }
 
 // Response message for GetUtilization
@@ -1104,6 +1110,9 @@ message GetCoverageOptionsRequest {
 
   // Optional. List of services.
   repeated string services = 10;
+
+  // Optional. Access group Id.
+  string accessGroupId = 11;
 }
 
 // Response message for GetCoverageOptions
@@ -1145,6 +1154,9 @@ message GetCoverageOndemandRequest {
 
   // Optional. List of services.
   repeated string services = 10;
+
+  // Optional. Access group Id.
+  string accessGroupId = 11;
 }
 
 // Response message for GetCoverageOndemand

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -2460,6 +2460,10 @@
                     "type": "string"
                   },
                   "description": "Optional. List of services."
+                },
+                "accessGroupId": {
+                  "type": "string",
+                  "description": "Optional. Access group Id."
                 }
               },
               "title": "Request message for GetCoverageOndemand"
@@ -2548,6 +2552,10 @@
                     "type": "string"
                   },
                   "description": "Optional. List of services."
+                },
+                "accessGroupId": {
+                  "type": "string",
+                  "description": "Optional. Access group Id."
                 }
               },
               "title": "Request message for GetCoverageOptions"
@@ -3219,6 +3227,10 @@
                     "type": "string"
                   },
                   "description": "Optional. List of services."
+                },
+                "accessGroupId": {
+                  "type": "string",
+                  "title": "Optional. Access group Id"
                 }
               },
               "title": "Request message for GetCostReduction"
@@ -3373,6 +3385,13 @@
           {
             "name": "groupId",
             "description": "Optional. Account group Id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "accessGroupId",
+            "description": "Optional. Access group Id.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -3917,6 +3936,15 @@
           "items": {
             "$ref": "#/definitions/apiOndemandChart"
           }
+        },
+        "companyId": {
+          "type": "string"
+        },
+        "billinggroupId": {
+          "type": "string"
+        },
+        "billinggroupName": {
+          "type": "string"
         }
       }
     },
@@ -3947,6 +3975,15 @@
           "items": {
             "$ref": "#/definitions/apiOptionsChart"
           }
+        },
+        "companyId": {
+          "type": "string"
+        },
+        "billinggroupId": {
+          "type": "string"
+        },
+        "billinggroupName": {
+          "type": "string"
         }
       }
     },
@@ -4064,6 +4101,15 @@
           "items": {
             "$ref": "#/definitions/apiChartData"
           }
+        },
+        "companyId": {
+          "type": "string"
+        },
+        "billinggroupId": {
+          "type": "string"
+        },
+        "billinggroupName": {
+          "type": "string"
         }
       }
     },
@@ -4514,13 +4560,18 @@
           "format": "double"
         },
         "operatingSystem": {
-          "type": "string"
+          "type": "string",
+          "title": "for amazon ec2 only"
         },
         "preInstalledSW": {
           "type": "string"
         },
         "tenancy": {
           "type": "string"
+        },
+        "dbEngine": {
+          "type": "string",
+          "title": "for amazon rds only"
         },
         "ondemandCost": {
           "type": "number",
@@ -4746,17 +4797,13 @@
     "protobufAny": {
       "type": "object",
       "properties": {
-        "typeUrl": {
+        "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "Must be a valid serialized protocol buffer of the above specified type."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "rippleOrg": {
       "type": "object",


### PR DESCRIPTION
This PR modifies makes the following modifications to cost-related structures to support Aqua access groups:
- Adds an access group ID variable to the `GetCostReductionRequest`, `GetUtilizationRequest`, `GetCoverageOptionsRequest` and `GetCoverageOndemandRequest` request DTOs. Although the access group ID is represented as the company ID in Aqua/Wave, we want to allow for explicit queries based off on or the other as the structure of the query will change depending on the data being requested.
- Adds `company_id`, `billinggroup_id` and `billinggroup_name` to the `OptionsData`, `OndemandData` and `UtilizationData` DTOs to allow for filtering based off of company ID, if requested from an access group query. The change to the `UtilizationData` DTO may not be strictly necessary for Wave/Aqua, but Blue users will certainly appreciate it.