### PR TITLE
Added Aqua link flag to DTO

### DIFF
--- a/api/grouprootuser.proto
+++ b/api/grouprootuser.proto
@@ -162,4 +162,7 @@ message FeatureFlags {
 
   // Control access to the report filters pane in Wave Pro
   bool report_filters = 33;
+
+  // Control access to Aqua from Wave Pro
+  bool aqua_link = 34;
 }


### PR DESCRIPTION
This PR adds the `aqua_link` feature flag to the feature flags DTO.