### PR TITLE
octo: modified api request in cost usage

### DIFF
--- a/api/cover/costforecast.proto
+++ b/api/cover/costforecast.proto
@@ -31,7 +31,6 @@ message IncludeForecast {
     // true if include the forecast
     bool include = 1;
 
-    
     string  startDate = 2;
 
     string endDate = 3;

--- a/api/cover/costforecast.proto
+++ b/api/cover/costforecast.proto
@@ -31,7 +31,7 @@ message IncludeForecast {
     // true if include the forecast
     bool include = 1;
 
-    string  startDate = 2;
+    string startDate = 2;
 
     string endDate = 3;
 

--- a/api/cover/costforecast.proto
+++ b/api/cover/costforecast.proto
@@ -26,3 +26,14 @@ message AwsCostForecast {
     double unblendedLowerBound = 8;
     double unblendedUpperBound = 9;
 }
+
+message IncludeForecast {
+    // true if include the forecast
+    bool include = 1;
+
+    
+    string  startDate = 2;
+
+    string endDate = 3;
+
+}

--- a/cover/v1/cover.proto
+++ b/cover/v1/cover.proto
@@ -1794,7 +1794,7 @@ message GetCostUsageRequest {
   GetCostUsageRequestCustomOptions customOptions = 13;
 
   // Optional. If set to true, include cost forecast for current month 
-  bool includeCostForecast = 9;
+  api.cover.IncludeForecast includeForecast = 14;
 }
 
 message GetCostUsageRequestAwsOptions {

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -14615,6 +14615,21 @@
         }
       }
     },
+    "coverIncludeForecast": {
+      "type": "object",
+      "properties": {
+        "include": {
+          "type": "boolean",
+          "title": "true if include the forecast"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        }
+      }
+    },
     "coverLayoutRequests": {
       "type": "object",
       "properties": {
@@ -18439,8 +18454,8 @@
           "$ref": "#/definitions/v1GetCostUsageRequestCustomOptions",
           "description": "Optional. For custom selection when creating cost groups.\nThis field allows custom options for specifying criteria for cost group creation."
         },
-        "includeCostForecast": {
-          "type": "boolean",
+        "includeForecast": {
+          "$ref": "#/definitions/coverIncludeForecast",
           "title": "Optional. If set to true, include cost forecast for current month"
         }
       }


### PR DESCRIPTION
This changes will be able to specify a date range specific to forecasted data only, previously the forecasted data is dependent on the cost usage main date range. This will provide more flexibility in budget management