### PR TITLE
octo: modify gcp account access

### DIFF
--- a/api/cover/accountaccess.proto
+++ b/api/cover/accountaccess.proto
@@ -20,9 +20,10 @@ message TagData {
 }
 
 message GcpOptions {
-    string projectName = 1;
-
-    string billingId = 2;
+    string accountName = 1;
+    
+    // where dataset is stored
+    string projectId = 2;
 
     string datasetId = 3;
 

--- a/cover/v1/cover.proto
+++ b/cover/v1/cover.proto
@@ -2511,7 +2511,7 @@ message ProcessAuth0UserResponse {
 
 // Message Response for GetDataAccess. For Azure and GCP
 message DataAccess {
-  // Project Id for GCP, Account Id for Azure
+  // Billing Id for GCP, Account Id for Azure
   string target = 1; 
 
   // Org Id
@@ -2542,7 +2542,7 @@ message RegisterDataAccessRequest {
   // Vendor (Azure/GCP)
   string vendor = 1;
 
-  // Project Id for GCP, Account Id for Azure
+  // Billing Id for GCP, Account Id for Azure
   string target = 2;
 
   // Account type (payer/linked)
@@ -2560,7 +2560,7 @@ message RegisterDataAccessRequest {
 
 // Request message for UpdateDataAccess (GCP/Azure)
 message UpdateDataAccessRequest {
-  // Project Id for GCP, Account Id for Azure
+  // Billing Id for GCP, Account Id for Azure
   string target = 1;
 
   // GCP or Azure
@@ -2575,8 +2575,8 @@ message UpdateDataAccessRequest {
   // AWS Options
   api.cover.AwsOptions awsOptions = 5;
   
-   // Account Type
-   string accountType = 6;
+  // Account Type
+  string accountType = 6;
 }
 
 // Request message for ListDataAccess
@@ -2601,7 +2601,7 @@ message BillingAccountRequest {
 }
 
 message GetAndDeleteDataAccessRequest {
-  // Required. (Project ID for GCP / Account ID for Azure) 
+  // Required. (Billing ID for GCP / Account ID for Azure) 
   string target = 1;
 
   // Vendor (GCP/Azure)

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -175,6 +175,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ExportAuditLogs rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -262,6 +263,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Admin.CreateCloudWatchMetricsStream rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -325,6 +327,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Admin.CreateDefaultCostAccess rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -407,6 +410,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -503,6 +507,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Admin.CreateNotificationChannel rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -559,6 +564,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -612,34 +618,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Required. Name of the notification channel."
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Required. Valid values: `email`, `slack`, `msteams`."
-                },
-                "email": {
-                  "$ref": "#/definitions/apiEmailChannel",
-                  "description": "Required if type = `email`."
-                },
-                "slack": {
-                  "$ref": "#/definitions/apiSlackChannel",
-                  "description": "Required if type = `slack`."
-                },
-                "msteams": {
-                  "$ref": "#/definitions/apiMSTeamsChannel",
-                  "description": "Required if type = `msteams`."
-                },
-                "product": {
-                  "type": "string",
-                  "description": "Optional. For Octo use only: `octo`."
-                }
-              },
-              "description": "Request message for the Admin.UpdateNotificationChannel rpc."
+              "$ref": "#/definitions/AdminUpdateNotificationChannelBody"
             }
           }
         ],
@@ -669,6 +648,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Admin.CreateDefaultNotificationChannel rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -723,6 +703,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Admin.SaveNotificationSettings rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -777,6 +758,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Admin.CreateNotificationTypeChannels rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -834,6 +816,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -894,29 +877,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "channels": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "title": "Required"
-                },
-                "enabled": {
-                  "type": "boolean",
-                  "title": "Required"
-                },
-                "notificationType": {
-                  "type": "string",
-                  "description": "Required\nValid values: \n`InvoiceCalculationStarted`, \n`InvoiceCalculationFinished`, \n`CurUpdatedAfterInvoice`.\n`AccountBudgetAlert`."
-                },
-                "account": {
-                  "$ref": "#/definitions/adminv1NotificationAccount",
-                  "description": "Optional. only available Wave(Pro)."
-                }
-              },
-              "description": "Request message for the Admin.UpdateNotificationTypeChannels rpc."
+              "$ref": "#/definitions/AdminUpdateNotificationBody"
             }
           }
         ],
@@ -976,6 +937,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.CreateApiClient rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -996,6 +958,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1120,6 +1083,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1204,13 +1168,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "featureFlags": {
-                  "$ref": "#/definitions/apiFeatureFlags"
-                }
-              },
-              "description": "Request message for the Iam.UpdateFeatureFlags rpc."
+              "$ref": "#/definitions/IamUpdateFeatureFlagsBody"
             }
           }
         ],
@@ -1248,6 +1206,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1261,6 +1220,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.CreateIdentityProvider rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1281,6 +1241,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1356,6 +1317,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.CreateIpFilter rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1376,6 +1338,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1463,8 +1426,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "description": "Request message for the Iam.CreatePartnerToken rpc."
+              "$ref": "#/definitions/IamCreatePartnerTokenBody"
             }
           }
         ],
@@ -1504,14 +1466,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": "string",
-                  "description": "Required. The previous (old) token to be refreshed."
-                }
-              },
-              "description": "Request message for the Iam.RefreshPartnerToken rpc."
+              "$ref": "#/definitions/IamRefreshPartnerTokenBody"
             }
           }
         ],
@@ -1541,6 +1496,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request for message Iam.ValidateVerificationCode rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1636,6 +1592,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.CreateRole rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1656,6 +1613,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1723,21 +1681,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "newName": {
-                  "type": "string",
-                  "description": "Optional. If set, update the current name to this."
-                },
-                "permissions": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Required. The list of permissions to attach to this role."
-                }
-              },
-              "description": "Request message for the Iam.UpdateRole rpc."
+              "$ref": "#/definitions/IamUpdateRoleBody"
             }
           }
         ],
@@ -1797,6 +1741,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.CreateUserRoleMapping rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1828,6 +1773,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.UpdateUserRoleMapping rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1891,6 +1837,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Iam.CreateUser rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1940,6 +1887,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2111,6 +2059,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2143,6 +2092,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2166,8 +2116,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "description": "Request message for the Operations.CancelOperation rpc."
+              "$ref": "#/definitions/OperationsCancelOperationBody"
             }
           }
         ],
@@ -2205,6 +2154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2239,6 +2189,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Organization.CreateOrg rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -2259,6 +2210,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2272,6 +2224,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Organization.UpdateMetadata rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -2292,6 +2245,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2305,6 +2259,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Organization.UpdatePassword rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -2325,6 +2280,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2348,6 +2304,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2358,6 +2315,14 @@
             }
           }
         },
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
         "tags": [
           "Organization"
         ]
@@ -2469,6 +2434,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAccessGroup rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -2527,6 +2493,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2580,25 +2547,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Optional. access group name. Set only the name to be changed.\n\nWe recommend the name length of 1~60 characters."
-                },
-                "description": {
-                  "type": "string",
-                  "description": "Optional. access group description. Set only the description to be changed.\n\nWe recommend the description length of 0~150 characters."
-                },
-                "billingGroups": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. Billing group to be included in the access group.\n\nYou can only include billing groups with the same calculation type and currency type.\nSet only the billingGroups to be changed.\nSpecify the billingInternalIds. For example: [`billingInternalId1`,`billingInternalId2`,`billingInternalId3`]"
-                }
-              },
-              "description": "Request message for the UpdateAccessGroup rpc."
+              "$ref": "#/definitions/BillingUpdateAccessGroupBody"
             }
           }
         ],
@@ -2615,6 +2564,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2628,6 +2578,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for Register Data Access. For azure and gcp.",
             "in": "body",
             "required": true,
             "schema": {
@@ -2693,14 +2644,14 @@
         "parameters": [
           {
             "name": "target",
-            "description": "Required. (Project ID for GCP / Account ID for Azure)",
+            "description": "Required. (Billing ID for GCP / Account ID for Azure)",
             "in": "path",
             "required": true,
             "type": "string"
           },
           {
             "name": "vendor",
-            "description": "Vendor (GCP/Azure).",
+            "description": "Vendor (GCP/Azure)",
             "in": "query",
             "required": false,
             "type": "string"
@@ -2724,6 +2675,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2737,14 +2689,14 @@
         "parameters": [
           {
             "name": "target",
-            "description": "Required. (Project ID for GCP / Account ID for Azure)",
+            "description": "Required. (Billing ID for GCP / Account ID for Azure)",
             "in": "path",
             "required": true,
             "type": "string"
           },
           {
             "name": "vendor",
-            "description": "Vendor (GCP/Azure).",
+            "description": "Vendor (GCP/Azure)",
             "in": "query",
             "required": false,
             "type": "string"
@@ -2768,6 +2720,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2781,7 +2734,7 @@
         "parameters": [
           {
             "name": "target",
-            "description": "Project Id for GCP, Account Id for Azure",
+            "description": "Billing Id for GCP, Account Id for Azure",
             "in": "path",
             "required": true,
             "type": "string"
@@ -2791,30 +2744,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "vendor": {
-                  "type": "string",
-                  "title": "GCP or Azure"
-                },
-                "gcpOptions": {
-                  "$ref": "#/definitions/coverGcpOptions",
-                  "title": "GCP Options"
-                },
-                "azureOptions": {
-                  "$ref": "#/definitions/coverAzureOptions",
-                  "title": "Azure Options"
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/apicoverAwsOptions",
-                  "title": "AWS Options"
-                },
-                "accountType": {
-                  "type": "string",
-                  "title": "Account Type"
-                }
-              },
-              "title": "Request message for UpdateDataAccess (GCP/Azure)"
+              "$ref": "#/definitions/CoverUpdateDataAccessBody"
             }
           }
         ],
@@ -2899,6 +2829,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2953,26 +2884,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "config": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiConfigFilters"
-                  },
-                  "description": "Required. \nA list of filtering options. See [api.ConfigFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
-                },
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiManagementAccount"
-                  },
-                  "description": "Optional."
-                }
-              },
-              "description": "Request message for the Billing.CreateAdjustmentConfig rpc."
+              "$ref": "#/definitions/BillingCreateAdjustmentConfigBody"
             }
           }
         ],
@@ -3010,26 +2922,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "config": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiConfigFilters"
-                  },
-                  "description": "Optional."
-                },
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiManagementAccount"
-                  },
-                  "description": "Optional."
-                }
-              },
-              "description": "Request message for the Billing.UpdateAdjustmentConfig rpc."
+              "$ref": "#/definitions/BillingUpdateAdjustmentConfigBody"
             }
           }
         ],
@@ -3060,6 +2953,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateBudgetAlerts rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -3080,6 +2974,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3175,6 +3070,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3205,6 +3101,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3228,32 +3125,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "title": "required. alert name"
-                },
-                "alertEnabled": {
-                  "type": "boolean",
-                  "description": "required."
-                },
-                "notificationChannels": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "required. Notification Channel Ids."
-                },
-                "frequency": {
-                  "type": "string",
-                  "description": "required. Frequency."
-                },
-                "costGroupId": {
-                  "type": "string",
-                  "title": "required. cost group id"
-                }
-              }
+              "$ref": "#/definitions/CoverUpdateAnomalyAlertBody"
             }
           }
         ],
@@ -3416,41 +3288,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "If optional fields are not supplied, no changes occur.\nOptional."
-                },
-                "fixedAmount": {
-                  "type": "number",
-                  "format": "float",
-                  "description": "Both are optional."
-                },
-                "percentage": {
-                  "type": "number",
-                  "format": "float"
-                },
-                "granularity": {
-                  "type": "string",
-                  "description": "Optional. daily or monthly. Only 'daily' is supported for now."
-                },
-                "costGroups": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. Cost group IDs."
-                },
-                "channels": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. Channel IDs."
-                }
-              },
-              "title": "Request message for UpdateAlertDetails"
+              "$ref": "#/definitions/CoverUpdateAlertDetailsBody"
             }
           }
         ],
@@ -3467,6 +3305,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3562,6 +3401,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3592,6 +3432,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3615,39 +3456,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "alertEnabled": {
-                  "type": "boolean",
-                  "description": "required."
-                },
-                "channels": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "required. Notification Channel Ids."
-                },
-                "frequencies": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "int64"
-                  },
-                  "description": "required. Frequencies."
-                },
-                "costGroups": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "title": "Required. Cost Group Ids"
-                },
-                "name": {
-                  "type": "string",
-                  "title": "required. Name"
-                }
-              }
+              "$ref": "#/definitions/CoverUpdateDiscountExpirationAlertBody"
             }
           }
         ],
@@ -3696,6 +3505,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3750,37 +3560,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "vendor": {
-                  "type": "string",
-                  "description": "Required. At the moment, only `aws` is supported."
-                },
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Required. Lsit of accountId. For example, you set to [\"accountId1\",\"accountId2\",\"accountId3\"]."
-                },
-                "notification": {
-                  "$ref": "#/definitions/apiBudgetAlertNotification",
-                  "description": "Required."
-                },
-                "daily": {
-                  "$ref": "#/definitions/apiDailyBudgetAlert",
-                  "description": "Optional."
-                },
-                "dailyRate": {
-                  "$ref": "#/definitions/apiDailyRateIncreaseBudgetAlert",
-                  "description": "Optional."
-                },
-                "monthly": {
-                  "$ref": "#/definitions/apiMonthlyBudgetAlert",
-                  "description": "Optional."
-                }
-              },
-              "description": "Request message for the UpdateBudgetAlerts rpc."
+              "$ref": "#/definitions/CostUpdateBudgetAlertsBody"
             }
           }
         ],
@@ -3820,6 +3600,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ReadBudgetAlerts rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -3862,6 +3643,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the RestoreAccountUsage rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -3904,6 +3686,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the RestoreAccountUsage rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -3946,6 +3729,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAllocator rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -3988,6 +3772,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ListFees rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4030,6 +3815,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the RestoreFee rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4072,6 +3858,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAllocator rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4114,6 +3901,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the GetCostGroupFee rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4156,6 +3944,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ListFees rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4198,6 +3987,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the RestoreSavings rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4240,6 +4030,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAllocator rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4282,6 +4073,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the GetCostGroupAllocation rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4345,6 +4137,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAllocator rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4365,6 +4158,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -4417,39 +4211,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "category": {
-                  "type": "string"
-                },
-                "expiration": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "startMonth": {
-                  "type": "string",
-                  "description": "Optional. The starting month of the allocator to be effective."
-                },
-                "defaultAccount": {
-                  "type": "string",
-                  "description": "Optional. The default account for remaining costs. If not set, will allocate the cost to the original account."
-                },
-                "criteria": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1Criteria"
-                  },
-                  "description": "Required. Criteria for the adjustment to be applied."
-                },
-                "allocator": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1Allocator"
-                  }
-                }
-              }
+              "$ref": "#/definitions/CoverUpdateAllocatorBody"
             }
           }
         ],
@@ -4583,6 +4345,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Asset.ListResources rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4679,6 +4442,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAccountAccess rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4721,6 +4485,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ListAccountAccess rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4754,6 +4519,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAccountAccess rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4787,6 +4553,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateAccountAccessStackset rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4883,6 +4650,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Cost.ImportCurFiles rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4925,6 +4693,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Billing.ListAwsCalculationHistory rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -4945,6 +4714,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -4978,6 +4748,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -5034,6 +4805,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -5126,6 +4898,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the Billing.CreateBillingGroup rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -5389,12 +5162,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "budgetData": {
-                  "$ref": "#/definitions/coverBudgetData"
-                }
-              }
+              "$ref": "#/definitions/CoverUpdateBudgetBody"
             }
           }
         ],
@@ -5600,22 +5368,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "title": "If optional fields are not supplied, no changes occur.\nOptional. Either actual email address or slack/msteams channel name"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Optional. email, slack, or msteams."
-                },
-                "webhookUrl": {
-                  "type": "string",
-                  "description": "Optional. Only needed for slack and msteams type."
-                }
-              },
-              "title": "Request message for UpdateChannelDetails"
+              "$ref": "#/definitions/CoverUpdateChannelDetailsBody"
             }
           }
         ],
@@ -5878,23 +5631,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "threshold": {
-                  "type": "number",
-                  "format": "float",
-                  "title": "Required"
-                },
-                "isPercentage": {
-                  "type": "boolean",
-                  "description": "Required. When set to true, the threshold is a percentage to the actual cost. Otherwise, it is a fixed amount."
-                },
-                "pastDataInMonths": {
-                  "type": "string",
-                  "format": "int64",
-                  "description": "Optional. The number of past months to be used in training the model. Note: This will affect the results of anomaly detection. Default and max is 9 while min is 1."
-                }
-              }
+              "$ref": "#/definitions/CoverSetCostGroupAnomalyOptionsBody"
             }
           }
         ],
@@ -5934,14 +5671,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "colorTheme": {
-                  "type": "string",
-                  "description": "Required. Color Theme."
-                }
-              },
-              "title": "Request message for UpdateCostGroupColorTheme"
+              "$ref": "#/definitions/CoverUpdateCostGroupColorThemeBody"
             }
           }
         ],
@@ -5981,13 +5711,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "combinations": {
-                  "$ref": "#/definitions/coverCombinations"
-                }
-              },
-              "title": "Request message for UpdateCostGroupCombinations"
+              "$ref": "#/definitions/CoverUpdateCostGroupCombinationsBody"
             }
           }
         ],
@@ -6027,14 +5751,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "type": "string",
-                  "description": "Required. Description."
-                }
-              },
-              "title": "Request message for UpdateCostGroupDescription"
+              "$ref": "#/definitions/CoverUpdateCostGroupDescriptionBody"
             }
           }
         ],
@@ -6074,13 +5791,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "anomaly": {
-                  "type": "boolean",
-                  "title": "Required. Only anomaly is supported as of now"
-                }
-              }
+              "$ref": "#/definitions/CoverSetCostGroupEventIndicatorBody"
             }
           }
         ],
@@ -6120,14 +5831,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "icon": {
-                  "type": "string",
-                  "description": "Required. Icon."
-                }
-              },
-              "title": "Request message for UpdateCostGroupIcon"
+              "$ref": "#/definitions/CoverUpdateCostGroupIconBody"
             }
           }
         ],
@@ -6167,14 +5871,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "image": {
-                  "type": "string",
-                  "description": "Required. Image."
-                }
-              },
-              "title": "Request message for UpdateCostGroupImage"
+              "$ref": "#/definitions/CoverUpdateCostGroupImageBody"
             }
           }
         ],
@@ -6214,14 +5911,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "userId": {
-                  "type": "string",
-                  "description": "Required. User Id."
-                }
-              },
-              "title": "Request message for AssignCostGroupMember"
+              "$ref": "#/definitions/CoverAssignCostGroupMemberBody"
             }
           }
         ],
@@ -6261,14 +5951,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "userId": {
-                  "type": "string",
-                  "description": "Required. User Id."
-                }
-              },
-              "title": "Request message for RemoveCostGroupMember"
+              "$ref": "#/definitions/CoverRemoveCostGroupMemberBody"
             }
           }
         ],
@@ -6308,14 +5991,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Required. Name."
-                }
-              },
-              "title": "Request message for UpdateCostGroupName"
+              "$ref": "#/definitions/CoverUpdateCostGroupNameBody"
             }
           }
         ],
@@ -6439,8 +6115,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "description": "Request message for the ListInvoiceStatus rpc."
+              "$ref": "#/definitions/BillingListInvoiceStatusBody"
             }
           }
         ],
@@ -6512,25 +6187,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "vendor": {
-                  "type": "string",
-                  "description": "Required. At the moment, only `aws` is supported."
-                },
-                "allGroups": {
-                  "type": "boolean",
-                  "description": "Optional. You can set all billing groups.\n\nIf this parameter is not set, The list set to `groups` is used."
-                },
-                "groups": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "title": "Optional. You can set it to a list of billing internal group id"
-                }
-              },
-              "description": "Request message for the CreateInvoice rpc."
+              "$ref": "#/definitions/BillingCreateInvoiceBody"
             }
           }
         ],
@@ -6570,14 +6227,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group or a comma-separated list of groups. ex) `group1,group2`. if want to set all group, set `*`. \n\nImplied as the parent billing group for Wave(Pro) users."
-                }
-              },
-              "description": "Request message for the ExportCostFiltersFile rpc."
+              "$ref": "#/definitions/BillingExportInvoiceFileBody"
             }
           }
         ],
@@ -6594,6 +6244,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -6617,25 +6268,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "allGroups": {
-                  "type": "boolean",
-                  "description": "Optional. You can set all billing groups.\n\nIf this parameter is not set, The list set to `groups` is used."
-                },
-                "groups": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "title": "Optional. You can set it to a list of billing internal group id"
-                },
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Required. You can set display or hiding.\n\nIf true, Hiding Invoice. If false, Display Invoice."
-                }
-              },
-              "description": "Request message for the UpdateInvoicePreviews rpc."
+              "$ref": "#/definitions/BillingUpdateInvoicePreviewsBody"
             }
           }
         ],
@@ -6675,14 +6308,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string",
-                  "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
-                }
-              },
-              "description": "Request message for the Cost.GetInvoiceRequest rpc."
+              "$ref": "#/definitions/BillingGetInvoiceBody"
             }
           }
         ],
@@ -6721,6 +6347,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ListInvoice rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -7627,14 +7254,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "isAdmin": {
-                  "type": "boolean",
-                  "description": "Required. IsAdmin."
-                }
-              },
-              "title": "Request message for UpdateMemberPermission"
+              "$ref": "#/definitions/CoverUpdateMemberPermissionBody"
             }
           }
         ],
@@ -7986,7 +7606,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object"
+              "$ref": "#/definitions/CoverExecuteOptimizationBody"
             }
           }
         ],
@@ -8077,21 +7697,21 @@
           },
           {
             "name": "startDate",
-            "description": "Required. Start date Format: \"YYYYMMDD\".",
+            "description": "Required. Start date Format: \"YYYYMMDD\"",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "endDate",
-            "description": "Required. End date Format: \"YYYYMMDD\".",
+            "description": "Required. End date Format: \"YYYYMMDD\"",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "reportType",
-            "description": "Required. Report Type. Valid inputs are: \"quarterly\", \"yearly\".",
+            "description": "Required. Report Type. Valid inputs are: \"quarterly\", \"yearly\"",
             "in": "query",
             "required": false,
             "type": "string"
@@ -8163,6 +7783,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the CreateReseller rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -8220,6 +7841,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -8273,47 +7895,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "type": "string",
-                  "description": "Optional."
-                },
-                "password": {
-                  "type": "string",
-                  "description": "Optional.\n\nWe recommend a password length of 8~32 characters. If you send 0 characters, a password will be generated automatically."
-                },
-                "waveConfig": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/rippleResellerConfig"
-                  },
-                  "description": "Set only the config to be changed.\nFor example, If you want to change only dashboardGraph, set `{\"waveConfig\": [{\"key\": \"dashboardGraph\",\"value\": true}]}` as a parameter",
-                  "title": "Optional. wave feature config"
-                },
-                "aquaConfig": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/rippleResellerConfig"
-                  },
-                  "description": "Set only the config to be changed.\nFor example, If you want to change only aqRiManagement, set `{\"waveConfig\": [{\"key\": \"aqRiManagement\",\"value\": true}]}` as a parameter",
-                  "title": "Optional. aqua feature config"
-                },
-                "notification": {
-                  "type": "boolean",
-                  "description": "Optional.\n\nIf valid when email or password is updated, you will be notified via email address.\nIf only waveConfig or aquaConfig is changed, it is ignored."
-                },
-                "updateMask": {
-                  "type": "string",
-                  "description": "Required."
-                }
-              },
-              "description": "Request message for the UpdateReseller rpc.",
-              "required": [
-                "updateMask"
-              ]
+              "$ref": "#/definitions/BillingUpdateResellerBody"
             }
           }
         ],
@@ -8410,6 +7992,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -8463,18 +8046,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1AccountServiceDiscounts"
-                  },
-                  "description": "Required."
-                }
-              },
-              "description": "Request message for the CreateAccountInvoiceServiceDiscounts rpc."
+              "$ref": "#/definitions/BillingCreateAccountInvoiceServiceDiscountsBody"
             }
           }
         ],
@@ -8512,18 +8084,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1AccountServiceDiscounts"
-                  },
-                  "description": "Required."
-                }
-              },
-              "description": "Request message for the UpdateAccountInvoiceServiceDiscounts rpc."
+              "$ref": "#/definitions/BillingUpdateAccountInvoiceServiceDiscountsBody"
             }
           }
         ],
@@ -8572,8 +8133,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "description": "Request message for the ListAccountInvoiceServiceDiscounts rpc."
+              "$ref": "#/definitions/BillingListAccountInvoiceServiceDiscountsBody"
             }
           }
         ],
@@ -8590,6 +8150,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -8613,17 +8174,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/v1AccountServiceDiscounts"
-                  },
-                  "description": "Required."
-                }
-              }
+              "$ref": "#/definitions/BillingRemoveAccountInvoiceServiceDiscountsBody"
             }
           }
         ],
@@ -8662,6 +8213,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ListInvoiceServiceDiscounts rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -8880,17 +8432,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "layout": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/coverWidgetData"
-                  }
-                }
-              },
-              "title": "Request message for UpdateViewLayout"
+              "$ref": "#/definitions/CoverUpdateViewLayoutBody"
             }
           }
         ],
@@ -8937,20 +8479,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "options": {
-                  "type": "object"
-                },
-                "requests": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/coverLayoutRequests"
-                  }
-                }
-              },
-              "title": "Request message for UpdateViewWidget"
+              "$ref": "#/definitions/CoverUpdateViewWidgetBody"
             }
           }
         ],
@@ -9083,28 +8612,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "icon": {
-                  "type": "string"
-                },
-                "isPrivate": {
-                  "type": "boolean"
-                },
-                "isEditable": {
-                  "type": "boolean"
-                },
-                "colorTheme": {
-                  "type": "string"
-                }
-              },
-              "title": "Request message for UpdateView"
+              "$ref": "#/definitions/CoverUpdateViewBody"
             }
           }
         ],
@@ -9143,13 +8651,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "colorTheme": {
-                  "type": "string"
-                }
-              },
-              "title": "Request message for UpdateViewColorTheme"
+              "$ref": "#/definitions/CoverUpdateViewColorThemeBody"
             }
           }
         ],
@@ -9189,13 +8691,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "menuItemId": {
-                  "type": "string"
-                }
-              },
-              "title": "Request message for AddSideMenuFavorite"
+              "$ref": "#/definitions/CoverAddSideMenuFavoriteBody"
             }
           }
         ],
@@ -9235,17 +8731,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "sidemenustate": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/coverSideMenuState"
-                  }
-                }
-              },
-              "title": "Request message for UpdateSideMenuState"
+              "$ref": "#/definitions/CoverUpdateSideMenuStateBody"
             }
           }
         ],
@@ -9285,13 +8771,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "menuItemId": {
-                  "type": "string"
-                }
-              },
-              "title": "Request message for RemoveSideMenuFavorite"
+              "$ref": "#/definitions/CoverRemoveSideMenuFavoriteBody"
             }
           }
         ],
@@ -9330,6 +8810,7 @@
         "parameters": [
           {
             "name": "body",
+            "description": "Request message for the ProxyCreateCompletion rpc.",
             "in": "body",
             "required": true,
             "schema": {
@@ -9403,18 +8884,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accountId": {
-                  "type": "string",
-                  "description": "Required. Account Id."
-                },
-                "payerId": {
-                  "type": "string",
-                  "description": "Required. The Payer Id."
-                }
-              },
-              "title": "Request message for AssignPayer"
+              "$ref": "#/definitions/CoverAssignPayerBody"
             }
           }
         ],
@@ -9431,6 +8901,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -9454,18 +8925,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accountId": {
-                  "type": "string",
-                  "description": "Required. The AWS account Id."
-                },
-                "accountName": {
-                  "type": "string",
-                  "title": "The account name"
-                }
-              },
-              "description": "Request message for the RegisterAccount rpc."
+              "$ref": "#/definitions/CoverRegisterAccountBody"
             }
           }
         ],
@@ -9558,30 +9018,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Required. The account id to register."
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Optional. If empty, set to the value of `id`."
-                },
-                "parent": {
-                  "type": "string",
-                  "description": "Optional. The parent `billingInternalId` of the billing group to which this account will belong to."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1CreateAccountRequestAwsOptions",
-                  "description": "Required for the `aws` vendor. AWS-specific options."
-                },
-                "gcpOptions": {
-                  "$ref": "#/definitions/v1CreateAccountRequestGcpOptions",
-                  "description": "Required for the `gcp` vendor. GCP-specific options."
-                }
-              },
-              "description": "Request message for the Cost.CreateAccount rpc."
+              "$ref": "#/definitions/CostCreateAccountBody"
             }
           }
         ],
@@ -9621,16 +9058,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accountIds": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Required. A comma-separated list of account ids. For example, you set to [\"accountId1\",\"accountId2\",\"accountId3\"]."
-                }
-              }
+              "$ref": "#/definitions/CostCheckAccountsBelongToMspBody"
             }
           }
         ],
@@ -9784,6 +9212,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -9851,14 +9280,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Optional."
-                }
-              },
-              "description": "Request message for the Cost.UpdateAccount rpc."
+              "$ref": "#/definitions/CostUpdateAccountBody"
             }
           }
         ],
@@ -9908,30 +9330,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. At the moment, only billing internal ids are supported. If set, reads the non-usage-based adjustment details of this group. Valid only if `accountId` is not set. If both `groupId` and `accountId` are not set, reads the adjustment details of the whole organization. Only valid for Ripple users. Implied (or discarded) for Wave(Pro) users."
-                },
-                "accountId": {
-                  "type": "string",
-                  "description": "Optional. If set, reads the non-usaged-based adjustment details of this account. Also invalidates the `groupId` value even if set. If both `groupId` and `accountId` are not set, reads the adjustment details of the whole organization."
-                },
-                "startTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
-                },
-                "endTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1ReadAdjustmentsRequestAwsOptions",
-                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the Cost.ReadAdjustments rpc."
+              "$ref": "#/definitions/CostReadAdjustmentsBody"
             }
           }
         ],
@@ -9985,6 +9384,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -10052,14 +9452,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "budgetAlert": {
-                  "$ref": "#/definitions/apiwaveBudgetAlert",
-                  "description": "Required. Budget alert setting."
-                }
-              },
-              "title": "Request message for CreateAccountBudgetAlerts"
+              "$ref": "#/definitions/CostCreateAccountBudgetAlertsBody"
             }
           }
         ],
@@ -10104,14 +9497,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "budgetAlert": {
-                  "$ref": "#/definitions/apiwaveBudgetAlert",
-                  "description": "Required. Budget alert setting.\n\nSet only the setting value to be changed.\nFor example, If you want to change only daily value, set `{\"budget\":[{\"id\":\"daily\",\"value\":100,\"enabled\":true}}` as a parameter\nThe same goes for notification. If you want to change only email value, set `{\"notification\":[{\"id\":\"email\",\"destination\":\"budgetalert-example@alphaus.cloud\",\"enabled\":true}}` as a parameter"
-                }
-              },
-              "title": "Request message for UpdateAccountBudgetAlerts"
+              "$ref": "#/definitions/CostUpdateAccountBudgetAlertsBody"
             }
           }
         ],
@@ -10181,6 +9567,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -10218,6 +9605,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -10248,13 +9636,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "$ref": "#/definitions/blueapiapiBudget"
-                }
-              },
-              "title": "Request message for UpdateAccountBudget"
+              "$ref": "#/definitions/CostUpdateAccountBudgetBody"
             }
           }
         ],
@@ -10359,13 +9741,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "$ref": "#/definitions/blueapiapiBudget"
-                }
-              },
-              "title": "Request message for CreateAccountBudget"
+              "$ref": "#/definitions/CostCreateAccountBudgetBody"
             }
           }
         ],
@@ -10481,34 +9857,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "schedule": {
-                  "type": "string",
-                  "description": "Required. The desired schedule in UTC, using the unix-cron string format `* * * * *` which is a set of five fields in a line using the order: `minute hour day-of-the-month month day-of-the-week`.\n\n* `minute` values can be `0-59`\n* `hour` values can be `0-23`\n* `day-of-the-month` values can be `1-31`\n* `month` values can be `1-12`, or `JAN-DEC`\n* `day-of-the-week` values can be `0-6`, or `SUN-SAT`, or `7` for Sunday\n\nSpecial characters:\n* A field can contain an asterisk (*), which always stands for \"first-last\".\n* Ranges are two numbers separated with a hyphen (-) and the specified range is inclusive.\n* Following a range with `/NUMBER` specifies skips of the number's value through the range. For example, both `0-23/2` and `*/2` can be used in the `hour` field to specify execution every two hours.\n* A list is a set of numbers (or ranges) separated by commas (,). For example, `1,2,5,6` in the `month` field specifies an execution on the first, second, fifth, and sixth days of the month."
-                },
-                "scheduleMacro": {
-                  "type": "string",
-                  "description": "Optional. Non-standard macro(s) that augment(s) `schedule`'s behavior. The only supported value for now is `@endofmonth`.\n\n`@endofmonth` - If set, the backend scheduler will only use the `minute` and `hour` part of `schedule`'s value and set the days to 28th, 29th, 30th, and 31st but the runner will do the filtering for the actual end of the trigger month. Note that this is different than setting `schedule` to, say, `0 0 28-31 * *`."
-                },
-                "targetMonth": {
-                  "type": "string",
-                  "description": "Optional. The desired month to calculate. If not set, defaults to previous month. The only supported value for now is `@current`.\n\n`@current` - If set, calculate for the month the schedule is triggered (or current month)."
-                },
-                "notificationChannel": {
-                  "type": "string",
-                  "description": "Optional. The channel id to use for notifications. At the moment, only email-type notification channels are supported. If not set, your default channel will be used. And if non-existent, an email-type notification channel will be created using your primary email address."
-                },
-                "force": {
-                  "type": "boolean",
-                  "description": "Optional. Not used at the moment."
-                },
-                "dryRun": {
-                  "type": "boolean",
-                  "description": "Optional. If set to true, skips the actual calculations. Useful as test, or reminder."
-                }
-              },
-              "description": "Request message for the Cost.CreateCalculationsSchedule rpc."
+              "$ref": "#/definitions/CostCreateCalculationsScheduleBody"
             }
           }
         ],
@@ -10525,6 +9874,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -10659,18 +10009,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "awsOptions": {
-                  "$ref": "#/definitions/v1CalculatorCostModifierAwsOptions",
-                  "description": "Required if `{vendor}` is `aws`. AWS-specific options."
-                },
-                "azureOptions": {
-                  "$ref": "#/definitions/v1CalculatorCostModifierAzureOptions",
-                  "description": "Required if `{vendor}` is `azure`. Azure-specific options."
-                }
-              },
-              "description": "Request message for the Cost.CreateCalculatorCostModifier rpc."
+              "$ref": "#/definitions/CostCreateCalculatorCostModifierBody"
             }
           }
         ],
@@ -10687,6 +10026,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -10759,14 +10099,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "month": {
-                  "type": "string",
-                  "description": "Optional. The UTC month to query. Defaults to current month if empty. Format is `yyyymm`. For example, June 2021 will be `202106`."
-                }
-              },
-              "description": "Request message for the Cost.ListCalculatorRunningAccounts rpc."
+              "$ref": "#/definitions/CostListCalculatorRunningAccountsBody"
             }
           }
         ],
@@ -10817,7 +10150,7 @@
           },
           {
             "name": "accountId",
-            "description": "Optional. You can set it to a single account or a comma-separated list of accounts. If set, overrides `groupId`.",
+            "description": "Optional. You can set it to a single account or a comma-separated list of accounts. If set, overrides `groupId`",
             "in": "query",
             "required": false,
             "type": "string"
@@ -10876,30 +10209,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. If set, reads the cost attributes of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the cost attributes of the whole organization. Optional for AWS Wave(Pro)."
-                },
-                "accountId": {
-                  "type": "string",
-                  "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the cost attributes of the whole organization."
-                },
-                "startTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
-                },
-                "endTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1ReadCostAttributesRequestAwsOptions",
-                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the Cost.ReadCostAttributes rpc."
+              "$ref": "#/definitions/CostReadCostAttributesBody"
             }
           }
         ],
@@ -10970,26 +10280,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "filterName": {
-                  "type": "string",
-                  "title": "Required. Filter Name. Specify characters between 1 ~ 100"
-                },
-                "groupId": {
-                  "type": "string",
-                  "description": "Required. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-                },
-                "accountId": {
-                  "type": "string",
-                  "description": "Required. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-                  "description": "Required. Valid only for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the CreateCostFilters rpc."
+              "$ref": "#/definitions/CostCreateCostFiltersBody"
             }
           }
         ],
@@ -11006,6 +10297,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -11073,26 +10365,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "filterName": {
-                  "type": "string",
-                  "title": "Required. Filter Name. Specify characters between 1 ~ 100"
-                },
-                "groupId": {
-                  "type": "string",
-                  "description": "Required. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-                },
-                "accountId": {
-                  "type": "string",
-                  "description": "Required. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-                  "description": "Required. Valid only for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the UpdateCostFilters rpc."
+              "$ref": "#/definitions/CostUpdateCostFiltersBody"
             }
           }
         ],
@@ -11139,30 +10412,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "startTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
-                },
-                "endTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmd`."
-                },
-                "groupByMonth": {
-                  "type": "boolean",
-                  "description": "Optional. If set to true, return data grouped by month within the date range. If you want data that is grouped per account per month, set this to `true`, then set `groupByColumns` to `none`."
-                },
-                "groupByColumns": {
-                  "type": "string",
-                  "description": "Optional. A comma-separated list of columns to aggregate the data into. Valid values are `productCode`, `serviceCode`, `region`, `zone`, `usageType`, `instanceType`, `operation`, `invoiceId`, `description`, and `resourceId`. A special value of `none` is also supported, which means query by date or month per account only.\n\nFor example, if you only want the services and region data, you can set this field to `productCode,region`. Your input sequence doesn't matter (although the sequence above is recommended) as the actual sequence is already fixed in the return data (see the definition in https://github.com/alphauslabs/blueapi/blob/main/api/aws/cost.proto), which is generic to specific, top to bottom. Invalid values are discarded. Excluded columns will be empty."
-                },
-                "includeTags": {
-                  "type": "boolean",
-                  "description": "Optional. If set to true, stream will include resource tags."
-                }
-              },
-              "description": "Request message for the ExportCostFiltersFile rpc."
+              "$ref": "#/definitions/CostExportCostFiltersFileBody"
             }
           }
         ],
@@ -11203,22 +10453,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. A comma-separated list of billing internal ids. If empty, calculate for all billing groups.\n\nAt the moment, for AWS, this is only valid for account type billing groups, not tag billing groups. If a tag billing group is provided, it is discarded and the calculation is done for the whole organization."
-                },
-                "month": {
-                  "type": "string",
-                  "description": "Optional. The UTC month to calculate. If empty, it defaults to the previous month. Format is `yyyymm`. For example, June 2021 will be `202106`."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1CalculateCostsRequestAwsOptions",
-                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the Cost.CalculateCosts rpc."
+              "$ref": "#/definitions/CostCalculateCostsBody"
             }
           }
         ],
@@ -11268,38 +10503,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-                },
-                "accountId": {
-                  "type": "string",
-                  "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-                },
-                "startTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
-                },
-                "endTime": {
-                  "type": "string",
-                  "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-                },
-                "gcpOptions": {
-                  "$ref": "#/definitions/v1ReadCostsRequestGcpOptions",
-                  "description": "Optional. Valid only for the `gcp` vendor. GCP-specific options."
-                },
-                "azureOptions": {
-                  "$ref": "#/definitions/v1ReadCostsRequestAzureOptions",
-                  "description": "Optional. Valid only for the `azure` vendor. Azure-specific options."
-                }
-              },
-              "description": "Request message for the Cost.ReadCosts rpc."
+              "$ref": "#/definitions/CostReadCostsBody"
             }
           }
         ],
@@ -11346,52 +10550,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "period": {
-                  "type": "string",
-                  "title": "Required. Available values: day, hour"
-                },
-                "fromDate": {
-                  "type": "string",
-                  "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
-                },
-                "toDate": {
-                  "type": "string",
-                  "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
-                },
-                "payerId": {
-                  "type": "string",
-                  "description": "Optional. Payer Id."
-                },
-                "billingInternalId": {
-                  "type": "string",
-                  "description": "Optional. Billing group Id."
-                },
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. Account group Id."
-                },
-                "costGroupId": {
-                  "type": "string",
-                  "title": "Optional. Cost Group Id, currently used in octo"
-                },
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. List of Account Ids."
-                },
-                "services": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. List of services."
-                }
-              },
-              "title": "Request message for GetCoverageOndemand"
+              "$ref": "#/definitions/CostGetCoverageOndemandBody"
             }
           }
         ],
@@ -11438,52 +10597,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "period": {
-                  "type": "string",
-                  "description": "Required. Available values: day, hour."
-                },
-                "fromDate": {
-                  "type": "string",
-                  "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
-                },
-                "toDate": {
-                  "type": "string",
-                  "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
-                },
-                "payerId": {
-                  "type": "string",
-                  "description": "Optional. Payer Id."
-                },
-                "billingInternalId": {
-                  "type": "string",
-                  "description": "Optional. Billing group Id."
-                },
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. Account group Id."
-                },
-                "costGroupId": {
-                  "type": "string",
-                  "title": "Optional. Cost Group Id"
-                },
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. List of Account Ids."
-                },
-                "services": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. List of services."
-                }
-              },
-              "title": "Request message for GetCoverageOptions"
+              "$ref": "#/definitions/CostGetCoverageOptionsBody"
             }
           }
         ],
@@ -11560,7 +10674,7 @@
           },
           {
             "name": "billingInternalId",
-            "description": "Optional. Company Id of Billing Group to retrieve. Default value is user's Company Id.",
+            "description": "Optional. Company Id of Billing Group to retrieve. Default value is user's Company Id",
             "in": "query",
             "required": false,
             "type": "string"
@@ -11805,22 +10919,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accountId": {
-                  "type": "string",
-                  "description": "Required."
-                },
-                "month": {
-                  "type": "string",
-                  "description": "Optional. The UTC month to query. If empty, defaults to current month. Format is `yyyymm`. For example, June 2021 will be `202106`."
-                },
-                "feeType": {
-                  "type": "string",
-                  "description": "Optional. If empty, defaults to all fee type. At the moment, only `Fee`,`Refund`,`Credit`,`SppDiscount`,`EdpDiscount`,`BundledDiscount` is supported."
-                }
-              },
-              "description": "Request message for the Billing.ReadInvoiceAdjustments rpc."
+              "$ref": "#/definitions/BillingReadInvoiceAdjustmentsBody"
             }
           }
         ],
@@ -11870,26 +10969,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "billingInternalId": {
-                  "type": "string",
-                  "description": "Required. The billing internal id to stream."
-                },
-                "startTime": {
-                  "type": "string",
-                  "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
-                },
-                "endTime": {
-                  "type": "string",
-                  "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-                },
-                "groupByMonths": {
-                  "type": "boolean",
-                  "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`. If not set, daily data will be returned."
-                }
-              },
-              "description": "Request message for the Cost.ReadNonTagCosts rpc."
+              "$ref": "#/definitions/CostReadNonTagCostsBody"
             }
           }
         ],
@@ -11900,13 +10980,23 @@
     },
     "/v1/{vendor}/payers": {
       "get": {
-        "summary": "Get list of all payers",
-        "operationId": "Cover_GetPayers",
+        "summary": "Lists vendor payer accounts.",
+        "description": "For AWS, these are management accounts (formerly known as master or payer accounts); for Azure, these are subscriptions, for GCP, these are projects.",
+        "operationId": "Cost_ListPayerAccounts",
         "responses": {
           "200": {
-            "description": "A successful response.",
+            "description": "A successful response.(streaming responses)",
             "schema": {
-              "$ref": "#/definitions/v1GetPayersResponse"
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/blueapiapiAccount"
+                },
+                "error": {
+                  "$ref": "#/definitions/googlerpcStatus"
+                }
+              },
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
@@ -11919,24 +11009,31 @@
         "parameters": [
           {
             "name": "vendor",
-            "description": "Required. Cloud vendor.",
+            "description": "Required. At the moment, only `aws` is supported.",
             "in": "path",
             "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fieldMask",
+            "description": "Optional. Get only the value that set fieldMask.\n\nsee more info: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto",
+            "in": "query",
+            "required": false,
             "type": "string"
           }
         ],
         "tags": [
-          "Cover"
+          "Cost"
         ]
       },
       "post": {
-        "summary": "Assign payer to a linked account",
-        "operationId": "Cover_AssignPayer",
+        "summary": "DEPRECATED: Registers a vendor payer account. This is now deprecated for AWS payer accounts. To register an AWS payer account, check out the 'CreateDefaultCostAccess' API.",
+        "operationId": "Cost_CreatePayerAccount",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1AssignPayerResponse"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
@@ -11949,7 +11046,7 @@
         "parameters": [
           {
             "name": "vendor",
-            "description": "Required. Cloud vendor.",
+            "description": "Required. At the moment, only `aws` is supported.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -11959,19 +11056,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "awsOptions": {
-                  "$ref": "#/definitions/v1CreatePayerAccountRequestAwsOptions",
-                  "description": "Required for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the Cost.CreatePayerAccount rpc."
+              "$ref": "#/definitions/CostCreatePayerAccountBody"
             }
           }
         ],
         "tags": [
-          "Cover"
+          "Cost"
         ]
       }
     },
@@ -12021,6 +11111,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -12185,25 +11276,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Required. List of Account Ids."
-                },
-                "costGroupId": {
-                  "type": "string",
-                  "description": "Required. For OCTO only."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1GetRecommendationsRequestAwsOptions",
-                  "title": "Required if vendor = 'aws'"
-                }
-              },
-              "title": "Request message for GetRecommendations"
+              "$ref": "#/definitions/CostGetRecommendationsBody"
             }
           }
         ],
@@ -12250,56 +11323,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "reductionDisplay": {
-                  "type": "string",
-                  "title": "Required. Valid values: 'all', 'reservation', 'savingsplan'"
-                },
-                "includeDetails": {
-                  "type": "boolean",
-                  "description": "Optional. If set to \"true\", details of the RI or SP list is returned. Default: false."
-                },
-                "fromDate": {
-                  "type": "string",
-                  "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
-                },
-                "toDate": {
-                  "type": "string",
-                  "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
-                },
-                "payerId": {
-                  "type": "string",
-                  "description": "Optional. Payer Id."
-                },
-                "billingInternalId": {
-                  "type": "string",
-                  "description": "Optional. Billing group Id."
-                },
-                "groupId": {
-                  "type": "string",
-                  "description": "Optional. Account group Id."
-                },
-                "costGroupId": {
-                  "type": "string",
-                  "description": "Optional. Cost Group Id used in octo."
-                },
-                "accounts": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. List of Account Ids."
-                },
-                "services": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Optional. List of services."
-                }
-              },
-              "title": "Request message for GetCostReduction"
+              "$ref": "#/definitions/CostGetCostReductionBody"
             }
           }
         ],
@@ -12377,26 +11401,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accountId": {
-                  "type": "string",
-                  "description": "Required. Account Id."
-                },
-                "resourceId": {
-                  "type": "string",
-                  "description": "Required. The resource Id."
-                },
-                "resourceType": {
-                  "type": "string",
-                  "description": "Required. The recommended resource type."
-                },
-                "region": {
-                  "type": "string",
-                  "description": "Required. Resource region."
-                }
-              },
-              "title": "Request message for ModifyResourceType"
+              "$ref": "#/definitions/CoverModifyResourceTypeBody"
             }
           }
         ],
@@ -12436,22 +11441,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accountId": {
-                  "type": "string",
-                  "description": "Required. Account Id."
-                },
-                "resourceId": {
-                  "type": "string",
-                  "description": "Required. The resource Id."
-                },
-                "region": {
-                  "type": "string",
-                  "description": "Required. Resource region."
-                }
-              },
-              "title": "Request message for TerminateResource"
+              "$ref": "#/definitions/CoverTerminateResourceBody"
             }
           }
         ],
@@ -12539,30 +11529,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "billingInternalId": {
-                  "type": "string",
-                  "description": "Required. The billing internal id to stream."
-                },
-                "startTime": {
-                  "type": "string",
-                  "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
-                },
-                "endTime": {
-                  "type": "string",
-                  "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-                },
-                "groupByMonths": {
-                  "type": "boolean",
-                  "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`. If not set, daily data will be returned."
-                },
-                "awsOptions": {
-                  "$ref": "#/definitions/v1ReadTagCostsRequestAwsOptions",
-                  "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-                }
-              },
-              "description": "Request message for the Cost.ReadTagCosts rpc."
+              "$ref": "#/definitions/CostReadTagCostsBody"
             }
           }
         ],
@@ -12759,14 +11726,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "fieldMask": {
-                  "type": "string",
-                  "description": "Optional. Get only the value that set fieldMask.\n\nsee more info: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto"
-                }
-              },
-              "description": "Request message for the Billing.ReadUntaggedGroups rpc."
+              "$ref": "#/definitions/BillingReadUntaggedGroupsBody"
             }
           }
         ],
@@ -12815,18 +11775,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "billingInternalId": {
-                  "type": "string",
-                  "description": "Optional. If empty, returns all billing groups."
-                },
-                "month": {
-                  "type": "string",
-                  "description": "Optional. If empty, defaults to current UTC month. Format: yyyymm."
-                }
-              },
-              "description": "Request message for the Billing.ListUsageCostsDrift rpc."
+              "$ref": "#/definitions/BillingListUsageCostsDriftBody"
             }
           }
         ],
@@ -12938,6 +11887,1404 @@
         }
       }
     },
+    "AdminUpdateNotificationBody": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Required"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Required"
+        },
+        "notificationType": {
+          "type": "string",
+          "description": "Required\nValid values: \n`InvoiceCalculationStarted`, \n`InvoiceCalculationFinished`, \n`CurUpdatedAfterInvoice`.\n`AccountBudgetAlert`."
+        },
+        "account": {
+          "$ref": "#/definitions/adminv1NotificationAccount",
+          "description": "Optional. only available Wave(Pro)."
+        }
+      },
+      "description": "Request message for the Admin.UpdateNotificationTypeChannels rpc."
+    },
+    "AdminUpdateNotificationChannelBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. Name of the notification channel."
+        },
+        "type": {
+          "type": "string",
+          "description": "Required. Valid values: `email`, `slack`, `msteams`."
+        },
+        "email": {
+          "$ref": "#/definitions/apiEmailChannel",
+          "description": "Required if type = `email`."
+        },
+        "slack": {
+          "$ref": "#/definitions/apiSlackChannel",
+          "description": "Required if type = `slack`."
+        },
+        "msteams": {
+          "$ref": "#/definitions/apiMSTeamsChannel",
+          "description": "Required if type = `msteams`."
+        },
+        "product": {
+          "type": "string",
+          "description": "Optional. For Octo use only: `octo`."
+        }
+      },
+      "description": "Request message for the Admin.UpdateNotificationChannel rpc."
+    },
+    "BillingCreateAccountInvoiceServiceDiscountsBody": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AccountServiceDiscounts"
+          },
+          "description": "Required."
+        }
+      },
+      "description": "Request message for the CreateAccountInvoiceServiceDiscounts rpc."
+    },
+    "BillingCreateAdjustmentConfigBody": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiConfigFilters"
+          },
+          "description": "Required. \nA list of filtering options. See [api.ConfigFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiManagementAccount"
+          },
+          "description": "Optional."
+        }
+      },
+      "description": "Request message for the Billing.CreateAdjustmentConfig rpc."
+    },
+    "BillingCreateInvoiceBody": {
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "Required. At the moment, only `aws` is supported."
+        },
+        "allGroups": {
+          "type": "boolean",
+          "description": "Optional. You can set all billing groups.\n\nIf this parameter is not set, The list set to `groups` is used."
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Optional. You can set it to a list of billing internal group id"
+        }
+      },
+      "description": "Request message for the CreateInvoice rpc."
+    },
+    "BillingExportInvoiceFileBody": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Optional.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group or a comma-separated list of groups. ex) `group1,group2`. if want to set all group, set `*`. \n\nImplied as the parent billing group for Wave(Pro) users."
+        }
+      },
+      "description": "Request message for the ExportCostFiltersFile rpc."
+    },
+    "BillingGetInvoiceBody": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
+        }
+      },
+      "description": "Request message for the Cost.GetInvoiceRequest rpc."
+    },
+    "BillingListAccountInvoiceServiceDiscountsBody": {
+      "type": "object",
+      "description": "Request message for the ListAccountInvoiceServiceDiscounts rpc."
+    },
+    "BillingListInvoiceStatusBody": {
+      "type": "object",
+      "description": "Request message for the ListInvoiceStatus rpc."
+    },
+    "BillingListUsageCostsDriftBody": {
+      "type": "object",
+      "properties": {
+        "billingInternalId": {
+          "type": "string",
+          "description": "Optional. If empty, returns all billing groups."
+        },
+        "month": {
+          "type": "string",
+          "description": "Optional. If empty, defaults to current UTC month. Format: yyyymm."
+        }
+      },
+      "description": "Request message for the Billing.ListUsageCostsDrift rpc."
+    },
+    "BillingReadInvoiceAdjustmentsBody": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Required."
+        },
+        "month": {
+          "type": "string",
+          "description": "Optional. The UTC month to query. If empty, defaults to current month. Format is `yyyymm`. For example, June 2021 will be `202106`."
+        },
+        "feeType": {
+          "type": "string",
+          "description": "Optional. If empty, defaults to all fee type. At the moment, only `Fee`,`Refund`,`Credit`,`SppDiscount`,`EdpDiscount`,`BundledDiscount` is supported."
+        }
+      },
+      "description": "Request message for the Billing.ReadInvoiceAdjustments rpc."
+    },
+    "BillingReadUntaggedGroupsBody": {
+      "type": "object",
+      "properties": {
+        "fieldMask": {
+          "type": "string",
+          "description": "Optional. Get only the value that set fieldMask.\n\nsee more info: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto"
+        }
+      },
+      "description": "Request message for the Billing.ReadUntaggedGroups rpc."
+    },
+    "BillingRemoveAccountInvoiceServiceDiscountsBody": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AccountServiceDiscounts"
+          },
+          "description": "Required."
+        }
+      }
+    },
+    "BillingUpdateAccessGroupBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Optional. access group name. Set only the name to be changed.\n\nWe recommend the name length of 1~60 characters."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional. access group description. Set only the description to be changed.\n\nWe recommend the description length of 0~150 characters."
+        },
+        "billingGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Billing group to be included in the access group.\n\nYou can only include billing groups with the same calculation type and currency type.\nSet only the billingGroups to be changed.\nSpecify the billingInternalIds. For example: [`billingInternalId1`,`billingInternalId2`,`billingInternalId3`]"
+        }
+      },
+      "description": "Request message for the UpdateAccessGroup rpc."
+    },
+    "BillingUpdateAccountInvoiceServiceDiscountsBody": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AccountServiceDiscounts"
+          },
+          "description": "Required."
+        }
+      },
+      "description": "Request message for the UpdateAccountInvoiceServiceDiscounts rpc."
+    },
+    "BillingUpdateAdjustmentConfigBody": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiConfigFilters"
+          },
+          "description": "Optional."
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiManagementAccount"
+          },
+          "description": "Optional."
+        }
+      },
+      "description": "Request message for the Billing.UpdateAdjustmentConfig rpc."
+    },
+    "BillingUpdateInvoicePreviewsBody": {
+      "type": "object",
+      "properties": {
+        "allGroups": {
+          "type": "boolean",
+          "description": "Optional. You can set all billing groups.\n\nIf this parameter is not set, The list set to `groups` is used."
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Optional. You can set it to a list of billing internal group id"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Required. You can set display or hiding.\n\nIf true, Hiding Invoice. If false, Display Invoice."
+        }
+      },
+      "description": "Request message for the UpdateInvoicePreviews rpc."
+    },
+    "BillingUpdateResellerBody": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "Optional."
+        },
+        "password": {
+          "type": "string",
+          "description": "Optional.\n\nWe recommend a password length of 8~32 characters. If you send 0 characters, a password will be generated automatically."
+        },
+        "waveConfig": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/rippleResellerConfig"
+          },
+          "description": "Set only the config to be changed.\nFor example, If you want to change only dashboardGraph, set `{\"waveConfig\": [{\"key\": \"dashboardGraph\",\"value\": true}]}` as a parameter",
+          "title": "Optional. wave feature config"
+        },
+        "aquaConfig": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/rippleResellerConfig"
+          },
+          "description": "Set only the config to be changed.\nFor example, If you want to change only aqRiManagement, set `{\"waveConfig\": [{\"key\": \"aqRiManagement\",\"value\": true}]}` as a parameter",
+          "title": "Optional. aqua feature config"
+        },
+        "notification": {
+          "type": "boolean",
+          "description": "Optional.\n\nIf valid when email or password is updated, you will be notified via email address.\nIf only waveConfig or aquaConfig is changed, it is ignored."
+        },
+        "updateMask": {
+          "type": "string",
+          "description": "Required."
+        }
+      },
+      "description": "Request message for the UpdateReseller rpc.",
+      "required": [
+        "updateMask"
+      ]
+    },
+    "CostCalculateCostsBody": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Optional. A comma-separated list of billing internal ids. If empty, calculate for all billing groups.\n\nAt the moment, for AWS, this is only valid for account type billing groups, not tag billing groups. If a tag billing group is provided, it is discarded and the calculation is done for the whole organization."
+        },
+        "month": {
+          "type": "string",
+          "description": "Optional. The UTC month to calculate. If empty, it defaults to the previous month. Format is `yyyymm`. For example, June 2021 will be `202106`."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1CalculateCostsRequestAwsOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the Cost.CalculateCosts rpc."
+    },
+    "CostCheckAccountsBelongToMspBody": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Required. A comma-separated list of account ids. For example, you set to [\"accountId1\",\"accountId2\",\"accountId3\"]."
+        }
+      }
+    },
+    "CostCreateAccountBody": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Required. The account id to register."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional. If empty, set to the value of `id`."
+        },
+        "parent": {
+          "type": "string",
+          "description": "Optional. The parent `billingInternalId` of the billing group to which this account will belong to."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1CreateAccountRequestAwsOptions",
+          "description": "Required for the `aws` vendor. AWS-specific options."
+        },
+        "gcpOptions": {
+          "$ref": "#/definitions/v1CreateAccountRequestGcpOptions",
+          "description": "Required for the `gcp` vendor. GCP-specific options."
+        }
+      },
+      "description": "Request message for the Cost.CreateAccount rpc."
+    },
+    "CostCreateAccountBudgetAlertsBody": {
+      "type": "object",
+      "properties": {
+        "budgetAlert": {
+          "$ref": "#/definitions/apiwaveBudgetAlert",
+          "description": "Required. Budget alert setting."
+        }
+      },
+      "title": "Request message for CreateAccountBudgetAlerts"
+    },
+    "CostCreateAccountBudgetBody": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/blueapiapiBudget"
+        }
+      },
+      "title": "Request message for CreateAccountBudget"
+    },
+    "CostCreateCalculationsScheduleBody": {
+      "type": "object",
+      "properties": {
+        "schedule": {
+          "type": "string",
+          "description": "Required. The desired schedule in UTC, using the unix-cron string format `* * * * *` which is a set of five fields in a line using the order: `minute hour day-of-the-month month day-of-the-week`.\n\n* `minute` values can be `0-59`\n* `hour` values can be `0-23`\n* `day-of-the-month` values can be `1-31`\n* `month` values can be `1-12`, or `JAN-DEC`\n* `day-of-the-week` values can be `0-6`, or `SUN-SAT`, or `7` for Sunday\n\nSpecial characters:\n* A field can contain an asterisk (*), which always stands for \"first-last\".\n* Ranges are two numbers separated with a hyphen (-) and the specified range is inclusive.\n* Following a range with `/NUMBER` specifies skips of the number's value through the range. For example, both `0-23/2` and `*/2` can be used in the `hour` field to specify execution every two hours.\n* A list is a set of numbers (or ranges) separated by commas (,). For example, `1,2,5,6` in the `month` field specifies an execution on the first, second, fifth, and sixth days of the month."
+        },
+        "scheduleMacro": {
+          "type": "string",
+          "description": "Optional. Non-standard macro(s) that augment(s) `schedule`'s behavior. The only supported value for now is `@endofmonth`.\n\n`@endofmonth` - If set, the backend scheduler will only use the `minute` and `hour` part of `schedule`'s value and set the days to 28th, 29th, 30th, and 31st but the runner will do the filtering for the actual end of the trigger month. Note that this is different than setting `schedule` to, say, `0 0 28-31 * *`."
+        },
+        "targetMonth": {
+          "type": "string",
+          "description": "Optional. The desired month to calculate. If not set, defaults to previous month. The only supported value for now is `@current`.\n\n`@current` - If set, calculate for the month the schedule is triggered (or current month)."
+        },
+        "notificationChannel": {
+          "type": "string",
+          "description": "Optional. The channel id to use for notifications. At the moment, only email-type notification channels are supported. If not set, your default channel will be used. And if non-existent, an email-type notification channel will be created using your primary email address."
+        },
+        "force": {
+          "type": "boolean",
+          "description": "Optional. Not used at the moment."
+        },
+        "dryRun": {
+          "type": "boolean",
+          "description": "Optional. If set to true, skips the actual calculations. Useful as test, or reminder."
+        }
+      },
+      "description": "Request message for the Cost.CreateCalculationsSchedule rpc."
+    },
+    "CostCreateCalculatorCostModifierBody": {
+      "type": "object",
+      "properties": {
+        "awsOptions": {
+          "$ref": "#/definitions/v1CalculatorCostModifierAwsOptions",
+          "description": "Required if `{vendor}` is `aws`. AWS-specific options."
+        },
+        "azureOptions": {
+          "$ref": "#/definitions/v1CalculatorCostModifierAzureOptions",
+          "description": "Required if `{vendor}` is `azure`. Azure-specific options."
+        }
+      },
+      "description": "Request message for the Cost.CreateCalculatorCostModifier rpc."
+    },
+    "CostCreateCostFiltersBody": {
+      "type": "object",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "title": "Required. Filter Name. Specify characters between 1 ~ 100"
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Required. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
+        },
+        "accountId": {
+          "type": "string",
+          "description": "Required. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
+          "description": "Required. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the CreateCostFilters rpc."
+    },
+    "CostCreatePayerAccountBody": {
+      "type": "object",
+      "properties": {
+        "awsOptions": {
+          "$ref": "#/definitions/v1CreatePayerAccountRequestAwsOptions",
+          "description": "Required for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the Cost.CreatePayerAccount rpc."
+    },
+    "CostExportCostFiltersFileBody": {
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmd`."
+        },
+        "groupByMonth": {
+          "type": "boolean",
+          "description": "Optional. If set to true, return data grouped by month within the date range. If you want data that is grouped per account per month, set this to `true`, then set `groupByColumns` to `none`."
+        },
+        "groupByColumns": {
+          "type": "string",
+          "description": "Optional. A comma-separated list of columns to aggregate the data into. Valid values are `productCode`, `serviceCode`, `region`, `zone`, `usageType`, `instanceType`, `operation`, `invoiceId`, `description`, and `resourceId`. A special value of `none` is also supported, which means query by date or month per account only.\n\nFor example, if you only want the services and region data, you can set this field to `productCode,region`. Your input sequence doesn't matter (although the sequence above is recommended) as the actual sequence is already fixed in the return data (see the definition in https://github.com/alphauslabs/blueapi/blob/main/api/aws/cost.proto), which is generic to specific, top to bottom. Invalid values are discarded. Excluded columns will be empty."
+        },
+        "includeTags": {
+          "type": "boolean",
+          "description": "Optional. If set to true, stream will include resource tags."
+        }
+      },
+      "description": "Request message for the ExportCostFiltersFile rpc."
+    },
+    "CostGetCostReductionBody": {
+      "type": "object",
+      "properties": {
+        "reductionDisplay": {
+          "type": "string",
+          "title": "Required. Valid values: 'all', 'reservation', 'savingsplan'"
+        },
+        "includeDetails": {
+          "type": "boolean",
+          "description": "Optional. If set to \"true\", details of the RI or SP list is returned. Default: false."
+        },
+        "fromDate": {
+          "type": "string",
+          "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
+        },
+        "toDate": {
+          "type": "string",
+          "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
+        },
+        "payerId": {
+          "type": "string",
+          "description": "Optional. Payer Id."
+        },
+        "billingInternalId": {
+          "type": "string",
+          "description": "Optional. Billing group Id."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Optional. Account group Id."
+        },
+        "costGroupId": {
+          "type": "string",
+          "description": "Optional. Cost Group Id used in octo."
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of Account Ids."
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of services."
+        }
+      },
+      "title": "Request message for GetCostReduction"
+    },
+    "CostGetCoverageOndemandBody": {
+      "type": "object",
+      "properties": {
+        "period": {
+          "type": "string",
+          "title": "Required. Available values: day, hour"
+        },
+        "fromDate": {
+          "type": "string",
+          "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
+        },
+        "toDate": {
+          "type": "string",
+          "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
+        },
+        "payerId": {
+          "type": "string",
+          "description": "Optional. Payer Id."
+        },
+        "billingInternalId": {
+          "type": "string",
+          "description": "Optional. Billing group Id."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Optional. Account group Id."
+        },
+        "costGroupId": {
+          "type": "string",
+          "title": "Optional. Cost Group Id, currently used in octo"
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of Account Ids."
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of services."
+        }
+      },
+      "title": "Request message for GetCoverageOndemand"
+    },
+    "CostGetCoverageOptionsBody": {
+      "type": "object",
+      "properties": {
+        "period": {
+          "type": "string",
+          "description": "Required. Available values: day, hour."
+        },
+        "fromDate": {
+          "type": "string",
+          "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
+        },
+        "toDate": {
+          "type": "string",
+          "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
+        },
+        "payerId": {
+          "type": "string",
+          "description": "Optional. Payer Id."
+        },
+        "billingInternalId": {
+          "type": "string",
+          "description": "Optional. Billing group Id."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Optional. Account group Id."
+        },
+        "costGroupId": {
+          "type": "string",
+          "title": "Optional. Cost Group Id"
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of Account Ids."
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of services."
+        }
+      },
+      "title": "Request message for GetCoverageOptions"
+    },
+    "CostGetRecommendationsBody": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Required. List of Account Ids."
+        },
+        "costGroupId": {
+          "type": "string",
+          "description": "Required. For OCTO only."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1GetRecommendationsRequestAwsOptions",
+          "title": "Required if vendor = 'aws'"
+        }
+      },
+      "title": "Request message for GetRecommendations"
+    },
+    "CostListCalculatorRunningAccountsBody": {
+      "type": "object",
+      "properties": {
+        "month": {
+          "type": "string",
+          "description": "Optional. The UTC month to query. Defaults to current month if empty. Format is `yyyymm`. For example, June 2021 will be `202106`."
+        }
+      },
+      "description": "Request message for the Cost.ListCalculatorRunningAccounts rpc."
+    },
+    "CostReadAdjustmentsBody": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Optional. At the moment, only billing internal ids are supported. If set, reads the non-usage-based adjustment details of this group. Valid only if `accountId` is not set. If both `groupId` and `accountId` are not set, reads the adjustment details of the whole organization. Only valid for Ripple users. Implied (or discarded) for Wave(Pro) users."
+        },
+        "accountId": {
+          "type": "string",
+          "description": "Optional. If set, reads the non-usaged-based adjustment details of this account. Also invalidates the `groupId` value even if set. If both `groupId` and `accountId` are not set, reads the adjustment details of the whole organization."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadAdjustmentsRequestAwsOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the Cost.ReadAdjustments rpc."
+    },
+    "CostReadCostAttributesBody": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Optional. If set, reads the cost attributes of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the cost attributes of the whole organization. Optional for AWS Wave(Pro)."
+        },
+        "accountId": {
+          "type": "string",
+          "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the cost attributes of the whole organization."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadCostAttributesRequestAwsOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the Cost.ReadCostAttributes rpc."
+    },
+    "CostReadCostsBody": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
+        },
+        "accountId": {
+          "type": "string",
+          "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+        },
+        "gcpOptions": {
+          "$ref": "#/definitions/v1ReadCostsRequestGcpOptions",
+          "description": "Optional. Valid only for the `gcp` vendor. GCP-specific options."
+        },
+        "azureOptions": {
+          "$ref": "#/definitions/v1ReadCostsRequestAzureOptions",
+          "description": "Optional. Valid only for the `azure` vendor. Azure-specific options."
+        }
+      },
+      "description": "Request message for the Cost.ReadCosts rpc."
+    },
+    "CostReadNonTagCostsBody": {
+      "type": "object",
+      "properties": {
+        "billingInternalId": {
+          "type": "string",
+          "description": "Required. The billing internal id to stream."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
+        },
+        "groupByMonths": {
+          "type": "boolean",
+          "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`. If not set, daily data will be returned."
+        }
+      },
+      "description": "Request message for the Cost.ReadNonTagCosts rpc."
+    },
+    "CostReadTagCostsBody": {
+      "type": "object",
+      "properties": {
+        "billingInternalId": {
+          "type": "string",
+          "description": "Required. The billing internal id to stream."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
+        },
+        "groupByMonths": {
+          "type": "boolean",
+          "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`. If not set, daily data will be returned."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadTagCostsRequestAwsOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the Cost.ReadTagCosts rpc."
+    },
+    "CostUpdateAccountBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Optional."
+        }
+      },
+      "description": "Request message for the Cost.UpdateAccount rpc."
+    },
+    "CostUpdateAccountBudgetAlertsBody": {
+      "type": "object",
+      "properties": {
+        "budgetAlert": {
+          "$ref": "#/definitions/apiwaveBudgetAlert",
+          "description": "Required. Budget alert setting.\n\nSet only the setting value to be changed.\nFor example, If you want to change only daily value, set `{\"budget\":[{\"id\":\"daily\",\"value\":100,\"enabled\":true}}` as a parameter\nThe same goes for notification. If you want to change only email value, set `{\"notification\":[{\"id\":\"email\",\"destination\":\"budgetalert-example@alphaus.cloud\",\"enabled\":true}}` as a parameter"
+        }
+      },
+      "title": "Request message for UpdateAccountBudgetAlerts"
+    },
+    "CostUpdateAccountBudgetBody": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/blueapiapiBudget"
+        }
+      },
+      "title": "Request message for UpdateAccountBudget"
+    },
+    "CostUpdateBudgetAlertsBody": {
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "Required. At the moment, only `aws` is supported."
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Required. Lsit of accountId. For example, you set to [\"accountId1\",\"accountId2\",\"accountId3\"]."
+        },
+        "notification": {
+          "$ref": "#/definitions/apiBudgetAlertNotification",
+          "description": "Required."
+        },
+        "daily": {
+          "$ref": "#/definitions/apiDailyBudgetAlert",
+          "description": "Optional."
+        },
+        "dailyRate": {
+          "$ref": "#/definitions/apiDailyRateIncreaseBudgetAlert",
+          "description": "Optional."
+        },
+        "monthly": {
+          "$ref": "#/definitions/apiMonthlyBudgetAlert",
+          "description": "Optional."
+        }
+      },
+      "description": "Request message for the UpdateBudgetAlerts rpc."
+    },
+    "CostUpdateCostFiltersBody": {
+      "type": "object",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "title": "Required. Filter Name. Specify characters between 1 ~ 100"
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Required. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
+        },
+        "accountId": {
+          "type": "string",
+          "description": "Required. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
+          "description": "Required. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Request message for the UpdateCostFilters rpc."
+    },
+    "CoverAddSideMenuFavoriteBody": {
+      "type": "object",
+      "properties": {
+        "menuItemId": {
+          "type": "string"
+        }
+      },
+      "title": "Request message for AddSideMenuFavorite"
+    },
+    "CoverAssignCostGroupMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Required. User Id."
+        }
+      },
+      "title": "Request message for AssignCostGroupMember"
+    },
+    "CoverAssignPayerBody": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Required. Account Id."
+        },
+        "payerId": {
+          "type": "string",
+          "description": "Required. The Payer Id."
+        }
+      },
+      "title": "Request message for AssignPayer"
+    },
+    "CoverExecuteOptimizationBody": {
+      "type": "object"
+    },
+    "CoverModifyResourceTypeBody": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Required. Account Id."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Required. The resource Id."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Required. The recommended resource type."
+        },
+        "region": {
+          "type": "string",
+          "description": "Required. Resource region."
+        }
+      },
+      "title": "Request message for ModifyResourceType"
+    },
+    "CoverRegisterAccountBody": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Required. The AWS account Id."
+        },
+        "accountName": {
+          "type": "string",
+          "title": "The account name"
+        }
+      },
+      "description": "Request message for the RegisterAccount rpc."
+    },
+    "CoverRemoveCostGroupMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Required. User Id."
+        }
+      },
+      "title": "Request message for RemoveCostGroupMember"
+    },
+    "CoverRemoveSideMenuFavoriteBody": {
+      "type": "object",
+      "properties": {
+        "menuItemId": {
+          "type": "string"
+        }
+      },
+      "title": "Request message for RemoveSideMenuFavorite"
+    },
+    "CoverSetCostGroupAnomalyOptionsBody": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "type": "number",
+          "format": "float",
+          "title": "Required"
+        },
+        "isPercentage": {
+          "type": "boolean",
+          "description": "Required. When set to true, the threshold is a percentage to the actual cost. Otherwise, it is a fixed amount."
+        },
+        "pastDataInMonths": {
+          "type": "string",
+          "format": "int64",
+          "description": "Optional. The number of past months to be used in training the model. Note: This will affect the results of anomaly detection. Default and max is 9 while min is 1."
+        }
+      }
+    },
+    "CoverSetCostGroupEventIndicatorBody": {
+      "type": "object",
+      "properties": {
+        "anomaly": {
+          "type": "boolean",
+          "title": "Required. Only anomaly is supported as of now"
+        }
+      }
+    },
+    "CoverTerminateResourceBody": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Required. Account Id."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Required. The resource Id."
+        },
+        "region": {
+          "type": "string",
+          "description": "Required. Resource region."
+        }
+      },
+      "title": "Request message for TerminateResource"
+    },
+    "CoverUpdateAlertDetailsBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "If optional fields are not supplied, no changes occur.\nOptional."
+        },
+        "fixedAmount": {
+          "type": "number",
+          "format": "float",
+          "description": "Both are optional."
+        },
+        "percentage": {
+          "type": "number",
+          "format": "float"
+        },
+        "granularity": {
+          "type": "string",
+          "description": "Optional. daily or monthly. Only 'daily' is supported for now."
+        },
+        "costGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Cost group IDs."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Channel IDs."
+        }
+      },
+      "title": "Request message for UpdateAlertDetails"
+    },
+    "CoverUpdateAllocatorBody": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string"
+        },
+        "expiration": {
+          "type": "string",
+          "format": "int64"
+        },
+        "startMonth": {
+          "type": "string",
+          "description": "Optional. The starting month of the allocator to be effective."
+        },
+        "defaultAccount": {
+          "type": "string",
+          "description": "Optional. The default account for remaining costs. If not set, will allocate the cost to the original account."
+        },
+        "criteria": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Criteria"
+          },
+          "description": "Required. Criteria for the adjustment to be applied."
+        },
+        "allocator": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Allocator"
+          }
+        }
+      }
+    },
+    "CoverUpdateAnomalyAlertBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "required. alert name"
+        },
+        "alertEnabled": {
+          "type": "boolean",
+          "description": "required."
+        },
+        "notificationChannels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "required. Notification Channel Ids."
+        },
+        "frequency": {
+          "type": "string",
+          "description": "required. Frequency."
+        },
+        "costGroupId": {
+          "type": "string",
+          "title": "required. cost group id"
+        }
+      }
+    },
+    "CoverUpdateBudgetBody": {
+      "type": "object",
+      "properties": {
+        "budgetData": {
+          "$ref": "#/definitions/coverBudgetData"
+        }
+      }
+    },
+    "CoverUpdateChannelDetailsBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "If optional fields are not supplied, no changes occur.\nOptional. Either actual email address or slack/msteams channel name"
+        },
+        "type": {
+          "type": "string",
+          "description": "Optional. email, slack, or msteams."
+        },
+        "webhookUrl": {
+          "type": "string",
+          "description": "Optional. Only needed for slack and msteams type."
+        }
+      },
+      "title": "Request message for UpdateChannelDetails"
+    },
+    "CoverUpdateCostGroupColorThemeBody": {
+      "type": "object",
+      "properties": {
+        "colorTheme": {
+          "type": "string",
+          "description": "Required. Color Theme."
+        }
+      },
+      "title": "Request message for UpdateCostGroupColorTheme"
+    },
+    "CoverUpdateCostGroupCombinationsBody": {
+      "type": "object",
+      "properties": {
+        "combinations": {
+          "$ref": "#/definitions/coverCombinations"
+        }
+      },
+      "title": "Request message for UpdateCostGroupCombinations"
+    },
+    "CoverUpdateCostGroupDescriptionBody": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Required. Description."
+        }
+      },
+      "title": "Request message for UpdateCostGroupDescription"
+    },
+    "CoverUpdateCostGroupIconBody": {
+      "type": "object",
+      "properties": {
+        "icon": {
+          "type": "string",
+          "description": "Required. Icon."
+        }
+      },
+      "title": "Request message for UpdateCostGroupIcon"
+    },
+    "CoverUpdateCostGroupImageBody": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Required. Image."
+        }
+      },
+      "title": "Request message for UpdateCostGroupImage"
+    },
+    "CoverUpdateCostGroupNameBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. Name."
+        }
+      },
+      "title": "Request message for UpdateCostGroupName"
+    },
+    "CoverUpdateDataAccessBody": {
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "title": "GCP or Azure"
+        },
+        "gcpOptions": {
+          "$ref": "#/definitions/coverGcpOptions",
+          "title": "GCP Options"
+        },
+        "azureOptions": {
+          "$ref": "#/definitions/coverAzureOptions",
+          "title": "Azure Options"
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/apicoverAwsOptions",
+          "title": "AWS Options"
+        },
+        "accountType": {
+          "type": "string",
+          "title": "Account Type"
+        }
+      },
+      "title": "Request message for UpdateDataAccess (GCP/Azure)"
+    },
+    "CoverUpdateDiscountExpirationAlertBody": {
+      "type": "object",
+      "properties": {
+        "alertEnabled": {
+          "type": "boolean",
+          "description": "required."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "required. Notification Channel Ids."
+        },
+        "frequencies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "int64"
+          },
+          "description": "required. Frequencies."
+        },
+        "costGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Required. Cost Group Ids"
+        },
+        "name": {
+          "type": "string",
+          "title": "required. Name"
+        }
+      }
+    },
+    "CoverUpdateMemberPermissionBody": {
+      "type": "object",
+      "properties": {
+        "isAdmin": {
+          "type": "boolean",
+          "description": "Required. IsAdmin."
+        }
+      },
+      "title": "Request message for UpdateMemberPermission"
+    },
+    "CoverUpdateSideMenuStateBody": {
+      "type": "object",
+      "properties": {
+        "sidemenustate": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverSideMenuState"
+          }
+        }
+      },
+      "title": "Request message for UpdateSideMenuState"
+    },
+    "CoverUpdateViewBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "isEditable": {
+          "type": "boolean"
+        },
+        "colorTheme": {
+          "type": "string"
+        }
+      },
+      "title": "Request message for UpdateView"
+    },
+    "CoverUpdateViewColorThemeBody": {
+      "type": "object",
+      "properties": {
+        "colorTheme": {
+          "type": "string"
+        }
+      },
+      "title": "Request message for UpdateViewColorTheme"
+    },
+    "CoverUpdateViewLayoutBody": {
+      "type": "object",
+      "properties": {
+        "layout": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverWidgetData"
+          }
+        }
+      },
+      "title": "Request message for UpdateViewLayout"
+    },
+    "CoverUpdateViewWidgetBody": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "object"
+        },
+        "requests": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverLayoutRequests"
+          }
+        }
+      },
+      "title": "Request message for UpdateViewWidget"
+    },
+    "IamCreatePartnerTokenBody": {
+      "type": "object",
+      "description": "Request message for the Iam.CreatePartnerToken rpc."
+    },
+    "IamRefreshPartnerTokenBody": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string",
+          "description": "Required. The previous (old) token to be refreshed."
+        }
+      },
+      "description": "Request message for the Iam.RefreshPartnerToken rpc."
+    },
+    "IamUpdateFeatureFlagsBody": {
+      "type": "object",
+      "properties": {
+        "featureFlags": {
+          "$ref": "#/definitions/apiFeatureFlags"
+        }
+      },
+      "description": "Request message for the Iam.UpdateFeatureFlags rpc."
+    },
+    "IamUpdateRoleBody": {
+      "type": "object",
+      "properties": {
+        "newName": {
+          "type": "string",
+          "description": "Optional. If set, update the current name to this."
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Required. The list of permissions to attach to this role."
+        }
+      },
+      "description": "Request message for the Iam.UpdateRole rpc."
+    },
     "IdentityProvidersamlInfo": {
       "type": "object",
       "properties": {
@@ -12984,6 +13331,10 @@
         }
       }
     },
+    "OperationsCancelOperationBody": {
+      "type": "object",
+      "description": "Request message for the Operations.CancelOperation rpc."
+    },
     "RoundingRoundingMethod": {
       "type": "string",
       "enum": [
@@ -13022,6 +13373,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiUsageDetails"
           },
           "title": "details: Vendor service fees included"
@@ -13029,6 +13381,7 @@
         "customDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiCustomDetails"
           },
           "title": "customDetails: Includes details of custom service and additional item data"
@@ -13036,6 +13389,7 @@
         "feeDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiFeeDetails"
           },
           "title": "feeDetails: Includes details of re-caluclated fee data"
@@ -13043,6 +13397,7 @@
         "total": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiAccountTotal"
           },
           "description": "substitution:\n   Total amount of agency fee costs\n\nsupportFee:\n   Total amount of Support Fee costs\n\nusageOnlyTotal:\n   Total amount of vendor usage fee only costs\n\nusageTotal:\n   Total amount of vendor usage fee costs\n\nmarketplace:\n   Total amount of vendor marketplace usage costs\n\nmarketplaceFees:\n   Total amount of vendor marketplace fee costs",
@@ -13065,6 +13420,7 @@
         "metadata": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the AccountGroup."
@@ -13072,6 +13428,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiAccount"
           }
         }
@@ -13120,6 +13477,7 @@
         "config": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiConfigFilters"
           },
           "title": "User configuration"
@@ -13131,6 +13489,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiManagementAccount"
           },
           "title": "Management account configuration"
@@ -13204,6 +13563,7 @@
         "data": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiForecastData"
           }
         }
@@ -13232,6 +13592,7 @@
         "channels": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiNotificationChannel"
           },
           "description": "List of channel info."
@@ -13285,6 +13646,7 @@
         "tags": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the costtag."
@@ -13510,7 +13872,8 @@
           "type": "string"
         },
         "frequency": {
-          "type": "string"
+          "type": "string",
+          "title": "daily, monthly"
         },
         "date": {
           "type": "string"
@@ -13761,6 +14124,7 @@
         "config": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiConfigFilters"
           },
           "description": "A list of filtering options. See [ConfigFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -13946,6 +14310,7 @@
         "ondemandChart": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiOndemandChart"
           }
         }
@@ -13976,6 +14341,7 @@
         "optionsChart": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiOptionsChart"
           }
         }
@@ -13996,6 +14362,7 @@
         "policies": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiPolicy"
           }
         }
@@ -14039,6 +14406,7 @@
         "policies": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiPolicy"
           }
         }
@@ -14132,6 +14500,7 @@
         "chartData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiChartData"
           }
         }
@@ -14143,6 +14512,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiAccountDetails"
           },
           "title": "details: Includes account-by-account details"
@@ -14150,6 +14520,7 @@
         "groupDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiGroupDetails"
           },
           "description": "groupDetails: Includes account-by-account details(fee item data)."
@@ -14157,6 +14528,7 @@
         "groupCustomDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiGroupCustomDetails"
           },
           "description": "groupCustomDetails: Includes account-by-account details(custom service and additional item data)."
@@ -14164,6 +14536,7 @@
         "total": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiInvoiceTotal"
           },
           "title": "total: Includes data on billing totals"
@@ -14331,6 +14704,7 @@
         "metadata": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "Various metadata associated with this lineitem."
@@ -14510,7 +14884,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "title": "account, subscription, project"
         }
       }
     },
@@ -14565,6 +14940,7 @@
         "threshold": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverThreshold"
           }
         },
@@ -14689,6 +15065,7 @@
         "notification": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiwaveNotification"
           },
           "description": "notification setting."
@@ -14696,6 +15073,7 @@
         "budget": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiwaveBudget"
           },
           "description": "budget setting."
@@ -14758,6 +15136,7 @@
         "chartData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiawsChartData"
           }
         }
@@ -14772,12 +15151,14 @@
         "riCostReductions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/awsRiCostReduction"
           }
         },
         "spCostReductions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/awsSpCostReduction"
           }
         }
@@ -14792,18 +15173,21 @@
         "riRecommendations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/awsRiRecommendation"
           }
         },
         "spRecommendations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/awsSpRecommendation"
           }
         },
         "estimatedCoverage": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/awsReservationEstimatedCoverage"
           }
         }
@@ -14819,6 +15203,7 @@
         "excludedServicesFromUsage": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/awsExcludedServiceFromUsage"
           },
           "description": "List of services that are of type 'Usage' in CUR that are excluded,\noptionally converted to Adjustments."
@@ -15296,6 +15681,7 @@
         "billingGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1BillingGroup"
           },
           "description": "A list of billing groups contained in the access group."
@@ -15341,6 +15727,7 @@
         "metadata": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the account."
@@ -15360,6 +15747,7 @@
         "monthlyBudget": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiMonthlyBudget"
           }
         }
@@ -15506,6 +15894,36 @@
         }
       }
     },
+    "costv1ListCostFilters": {
+      "type": "object",
+      "properties": {
+        "filterId": {
+          "type": "string",
+          "description": "Required. Filter Id."
+        },
+        "filterName": {
+          "type": "string",
+          "description": "Required. Filter Name."
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Required. Vendor."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
+        },
+        "accountId": {
+          "type": "string",
+          "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
+        }
+      },
+      "description": "Response message for the ListCostFilters rpc."
+    },
     "coverAPNDetails": {
       "type": "object",
       "properties": {
@@ -15630,18 +16048,21 @@
         "email": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverAlertChannel"
           }
         },
         "slack": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverAlertChannel"
           }
         },
         "msteams": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverAlertChannel"
           }
         }
@@ -15673,6 +16094,7 @@
         "costGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverAlertCostGroup"
           }
         },
@@ -15763,12 +16185,14 @@
         "riRecommendations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverRiRecommendationResults"
           }
         },
         "spRecommendations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverSpRecommendationResults"
           }
         }
@@ -15831,13 +16255,16 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "title": "not required for creating budget"
         },
         "startDate": {
-          "type": "string"
+          "type": "string",
+          "title": "use yyyymmdd format"
         },
         "endDate": {
-          "type": "string"
+          "type": "string",
+          "title": "use yyyymmdd format"
         },
         "totalBudget": {
           "type": "number",
@@ -15845,13 +16272,16 @@
         },
         "period": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "title": "3, 6, 12 months"
         },
         "granularBudget": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverGranularBudgetData"
-          }
+          },
+          "title": "budget per month"
         },
         "costGroup": {
           "$ref": "#/definitions/coverAlertCostGroup"
@@ -15859,42 +16289,55 @@
         "alerts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apicoverBudgetAlert"
-          }
+          },
+          "title": "threshold(s) and its respective channel(s) to alert"
         },
         "forecastedData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverGranularForecastData"
-          }
+          },
+          "title": "forecast for ongoing months of an active budget; if expired, archived forecast record"
         },
         "spendingData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverGranularSpendingData"
-          }
+          },
+          "title": "spending data"
         },
         "expired": {
-          "type": "boolean"
+          "type": "boolean",
+          "title": "true if budget has expired"
         },
         "draft": {
-          "type": "boolean"
+          "type": "boolean",
+          "title": "true if the current budget set is still a draft"
         },
         "createdBy": {
-          "type": "string"
+          "type": "string",
+          "title": "not required for creating budget"
         },
         "createdAt": {
-          "type": "string"
+          "type": "string",
+          "title": "not required for creating budget"
         },
         "updatedBy": {
-          "type": "string"
+          "type": "string",
+          "title": "not required for creating budget"
         },
         "updatedAt": {
-          "type": "string"
+          "type": "string",
+          "title": "not required for creating budget"
         },
         "totalSpend": {
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "title": "total accumulated spending within the budget period"
         }
       }
     },
@@ -15916,10 +16359,12 @@
           "type": "string"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "title": "actual email value of channel name in slack or ms teams"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "title": "email, slack, msteams"
         },
         "webhookUrl": {
           "type": "string"
@@ -15982,6 +16427,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" column filters. The key indicates the column name while the value is the filter value prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like to filter `productCode` to return only `AmazonEC2`, set to `{\"productCode\":\"eq:AmazonEC2\"}` or `{\"productCode\":\"AmazonEC2\"}`. You can also use a regular expression like `{\"productCode\":\"re:AmazonEC2|AmazonRDS\"}`, which means return all AmazonEC2 or AmazonRDS lineitems. Or reverse regexp, such as `{\"productCode\":\"!re:^AmazonEC2$\"}`, which means return all items except `AmazonEC2`."
@@ -15989,6 +16435,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestAwsOptionsFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" tag filters. The key indicates the tag key while the value is the filter tag value which can be prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you want to query lineitems with the tag `project:MY_PROJECT`, set to `{\"project\":\"MY_PROJECT\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
@@ -16002,6 +16449,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" column filters. The key indicates the column name while the value is the filter value prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like to filter `productCode` to return only `AmazonEC2`, set to `{\"productCode\":\"eq:AmazonEC2\"}` or `{\"productCode\":\"AmazonEC2\"}`. You can also use a regular expression like `{\"productCode\":\"re:AmazonEC2|AmazonRDS\"}`, which means return all AmazonEC2 or AmazonRDS lineitems. Or reverse regexp, such as `{\"productCode\":\"!re:^AmazonEC2$\"}`, which means return all items except `AmazonEC2`."
@@ -16009,6 +16457,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestAwsOptionsFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" tag filters. The key indicates the tag key while the value is the filter tag value which can be prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you want to query lineitems with the tag `project:MY_PROJECT`, set to `{\"project\":\"MY_PROJECT\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
@@ -16022,6 +16471,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" column filters. The key indicates the column name while the value is the filter value prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like to filter `productCode` to return only `AmazonEC2`, set to `{\"productCode\":\"eq:AmazonEC2\"}` or `{\"productCode\":\"AmazonEC2\"}`. You can also use a regular expression like `{\"productCode\":\"re:AmazonEC2|AmazonRDS\"}`, which means return all AmazonEC2 or AmazonRDS lineitems. Or reverse regexp, such as `{\"productCode\":\"!re:^AmazonEC2$\"}`, which means return all items except `AmazonEC2`."
@@ -16029,6 +16479,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestAwsOptionsFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" tag filters. The key indicates the tag key while the value is the filter tag value which can be prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you want to query lineitems with the tag `project:MY_PROJECT`, set to `{\"project\":\"MY_PROJECT\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
@@ -16042,6 +16493,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -16079,6 +16531,7 @@
         "members": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverMemberUserData"
           }
         },
@@ -16102,6 +16555,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Optional. A list of filtering options. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc.\nA map of \"key:value\" column filters. The key indicates the column name while the value is the filter value prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like to filter `serviceDescriptinon` to return only `Cloud Spanner`, set to `{\"serviceDescription\":\"eq:Cloud Spanner\"}` or `{\"serviceDescription\":\"Cloud Spanner\"}`. You can also use a regular expression like `{\"serviceDescription\":\"re:Cloud Spanner|BigQuery\"}`, which means return all Cloud Spanner or BigQuery lineitems. Or reverse regexp, such as `{\"serviceDescription\":\"!re:^Cloud Spanner$\"}`, which means return all items except `Cloud Spanner`."
@@ -16109,6 +16563,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Tags on gcp used to conditionally allow or deny policies based on whether a supported resource has a specific tag.\nSuppose you have a set of virtual machines (VMs) running various applications, and you want to distinguish between them based on their roles. You could assign tags like \"app:webserver\" and \"app:database\" to identify which VMs serve as web servers and which ones are database servers.\nIf you want to query lineitems with the tag `app:database`, set to `{\"app\":\"database\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
@@ -16116,6 +16571,7 @@
         "labelFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Labels on gcp help you organize resources and manage your costs at scale, with the granularity you need.\nFor example, on Compute Engine, you can use labels to group VMs in categories such as production, staging, or development so that you can search for resources that belong to each development stage.\nIf you want to query lineitems with the label `vm-prod: prod`, set to `{\"vm-prod\":\"prod\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
@@ -16123,6 +16579,7 @@
         "projectLabelFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupOptionsFilters"
           },
           "description": "Project Labels refers to labels that have been assigned to GCP projects. \nFor example, projectId \"mobingi-main\" assigned as \"env:prod\"\nIf you want to query lineitems with the label `env: prod`, set to `{\"env\":\"prod\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
@@ -16201,18 +16658,21 @@
         "eC2CpuUtilization": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverEC2CpuUtilization"
           }
         },
         "eC2DiskUtilization": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverEC2DiskUtilization"
           }
         },
         "eC2MemoryUtilization": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverEC2MemoryUtilization"
           }
         }
@@ -16611,11 +17071,12 @@
     "coverGcpOptions": {
       "type": "object",
       "properties": {
-        "projectName": {
+        "accountName": {
           "type": "string"
         },
-        "billingId": {
-          "type": "string"
+        "projectId": {
+          "type": "string",
+          "title": "where dataset is stored"
         },
         "datasetId": {
           "type": "string"
@@ -16629,7 +17090,8 @@
       "type": "object",
       "properties": {
         "date": {
-          "type": "string"
+          "type": "string",
+          "title": "use yyyymm format"
         },
         "budget": {
           "type": "number",
@@ -16641,7 +17103,8 @@
       "type": "object",
       "properties": {
         "date": {
-          "type": "string"
+          "type": "string",
+          "title": "use yyyymm format"
         },
         "mid": {
           "type": "number",
@@ -16661,11 +17124,13 @@
       "type": "object",
       "properties": {
         "date": {
-          "type": "string"
+          "type": "string",
+          "title": "use yyyymm format"
         },
         "value": {
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "title": "actual cost for the month"
         }
       }
     },
@@ -16817,6 +17282,7 @@
         "costGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverMemberCostGroup"
           }
         },
@@ -17071,6 +17537,7 @@
         "recommendationDetail": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverRecommendationDetail"
           }
         },
@@ -17170,6 +17637,7 @@
         "riRecommendationDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverRiRecommendationDetails"
           }
         }
@@ -17394,6 +17862,7 @@
         "spRecommendationDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverSpRecommendationDetails"
           }
         }
@@ -17438,11 +17907,13 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "title": "exact or percentage"
         },
         "value": {
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "title": "actual value of threshold"
         }
       }
     },
@@ -17593,6 +18064,7 @@
         "costGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverMemberCostGroup"
           }
         },
@@ -17655,6 +18127,7 @@
         "layout": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverWidgetData"
           }
         },
@@ -17735,6 +18208,7 @@
         "requests": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverLayoutRequests"
           }
         }
@@ -17830,6 +18304,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."
@@ -17840,13 +18315,13 @@
     "protobufAny": {
       "type": "object",
       "properties": {
-        "typeUrl": {
+        "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
       "additionalProperties": {},
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "protobufNullValue": {
       "type": "string",
@@ -17854,7 +18329,7 @@
         "NULL_VALUE"
       ],
       "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     },
     "protosOperation": {
       "type": "object",
@@ -17888,18 +18363,12 @@
         "percentage": {
           "type": "integer",
           "format": "int32",
-          "description": "Required.  This value can be up to 100.",
-          "required": [
-            "percentage"
-          ]
+          "description": "Required.  This value can be up to 100."
         },
         "fixed": {
           "type": "integer",
           "format": "int32",
-          "description": "Required.",
-          "required": [
-            "fixed"
-          ]
+          "description": "Required."
         }
       },
       "description": "Assigned resource definition.",
@@ -17926,6 +18395,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "A list of accounts."
@@ -17955,6 +18425,7 @@
         "exchangeRate": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleExchangeRate"
           },
           "description": "The exchange rate."
@@ -18022,18 +18493,21 @@
         "aws": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleExchangeRate"
           }
         },
         "gcp": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleExchangeRate"
           }
         },
         "azure": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleExchangeRate"
           }
         }
@@ -18139,6 +18613,7 @@
         "metadata": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the account."
@@ -18146,6 +18621,7 @@
         "members": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "List of all members under this payer."
@@ -18167,6 +18643,7 @@
         "exchangeRate": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleExchangeRate"
           },
           "description": "The exchange rate."
@@ -18204,6 +18681,7 @@
         "waveConfig": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleResellerConfig"
           },
           "title": "wave feature config"
@@ -18211,6 +18689,7 @@
         "aquaConfig": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleResellerConfig"
           },
           "title": "aqua feature config"
@@ -18250,10 +18729,7 @@
         },
         "name": {
           "type": "string",
-          "title": "Required. The unique name of the untagged group. This value can be up to 60",
-          "required": [
-            "name"
-          ]
+          "title": "Required. The unique name of the untagged group. This value can be up to 60"
         },
         "assigned": {
           "$ref": "#/definitions/rippleAssigned",
@@ -18262,6 +18738,7 @@
         "billingGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleAssignedBillingGroup"
           },
           "description": "Optional."
@@ -18288,18 +18765,21 @@
         "aws": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ripplePayerExchangeRate"
           }
         },
         "gcp": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ripplePayerExchangeRate"
           }
         },
         "azure": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ripplePayerExchangeRate"
           }
         }
@@ -18898,19 +19378,6 @@
       },
       "title": "Request message for AddPartnerCenterCredentials"
     },
-    "v1AddSideMenuFavoriteRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string",
-          "description": "Required. View Id."
-        },
-        "menuItemId": {
-          "type": "string"
-        }
-      },
-      "title": "Request message for AddSideMenuFavorite"
-    },
     "v1AddSideMenuFavoriteResponse": {
       "type": "object",
       "properties": {
@@ -19065,20 +19532,6 @@
         }
       }
     },
-    "v1AssignCostGroupMemberRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "userId": {
-          "type": "string",
-          "description": "Required. User Id."
-        }
-      },
-      "title": "Request message for AssignCostGroupMember"
-    },
     "v1AssignCostGroupMemberResponse": {
       "type": "object",
       "properties": {
@@ -19090,24 +19543,6 @@
         }
       },
       "title": "Response message for AssignCostGroupMember"
-    },
-    "v1AssignPayerRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. Cloud vendor."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required. Account Id."
-        },
-        "payerId": {
-          "type": "string",
-          "description": "Required. The Payer Id."
-        }
-      },
-      "title": "Request message for AssignPayer"
     },
     "v1AssignPayerResponse": {
       "type": "object",
@@ -19136,6 +19571,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1AwsDailyRunHistoryAccount"
           }
         }
@@ -19151,6 +19587,7 @@
         "history": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/AccountHistory"
           }
         }
@@ -19212,6 +19649,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiAccount"
           },
           "title": "List of all accounts"
@@ -19219,6 +19657,7 @@
         "tags": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiCostTag"
           },
           "title": "List of all tags"
@@ -19243,6 +19682,7 @@
         "aws": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiAdditionalItems"
           },
           "title": "AWS additional items"
@@ -19250,6 +19690,7 @@
         "azure": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiAdditionalItems"
           },
           "title": "Azure additional items"
@@ -19257,6 +19698,7 @@
         "gcp": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiAdditionalItems"
           },
           "title": "GCP additional items"
@@ -19359,6 +19801,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Lsit of accountId."
@@ -19381,28 +19824,6 @@
         }
       },
       "description": "Request message for the BudgetAlerts rpc."
-    },
-    "v1CalculateCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. A comma-separated list of billing internal ids. If empty, calculate for all billing groups.\n\nAt the moment, for AWS, this is only valid for account type billing groups, not tag billing groups. If a tag billing group is provided, it is discarded and the calculation is done for the whole organization."
-        },
-        "month": {
-          "type": "string",
-          "description": "Optional. The UTC month to calculate. If empty, it defaults to the previous month. Format is `yyyymm`. For example, June 2021 will be `202106`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CalculateCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CalculateCosts rpc."
     },
     "v1CalculateCostsRequestAwsOptions": {
       "type": "object",
@@ -19500,6 +19921,7 @@
         "qualifiers": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1CalculatorCostModifierAwsOptionsQualifier"
           },
           "description": "Optional. Conditional qualifiers to further filter the modifier targets. Multiple qualifiers use the logical `or` operator; `qualifiers[0] || qualifiers[1] || qualifiers[n]`."
@@ -19589,6 +20011,7 @@
         "qualifiers": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1CalculatorCostModifierAzureOptionsQualifier"
           },
           "description": "Optional. Conditional qualifiers to further filter the modifier targets. Multiple qualifiers use the logical `or` operator; `qualifiers[0] || qualifiers[1] || qualifiers[n]`."
@@ -19644,32 +20067,6 @@
         }
       },
       "description": "A map of \"key:value\" attribute filters. The key indicates the column name while the value is the filter value prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like your modifiers to apply to `productId:CFQ7TTC0LFLX` (Microsoft 365 E3), set to `{\"productId\":\"eq:CFQ7TTC0LFLX\"}` or `{\"productId\":\"CFQ7TTC0LFLX\"}`. You can also use a regular expression like `{\"productId\":\"re:CFQ7TTC0LFLX|DZH318Z0BQ4L\"}`, which means apply to all `Microsoft 365 E3` or `Virtual Machines Ev3 Series` lineitems. Or reverse regexp, such as `{\"productId\":\"!re:^CFQ7TTC0LFLX$\"}`, which means apply to all items except `Microsoft 365 E3`. Valid keys are `productId`, `productName`, `skuId`, `skuName`, `descriptiom`, `category` and `domainName`."
-    },
-    "v1CancelOperationRequest": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the operation resource to be cancelled."
-        }
-      },
-      "description": "Request message for the Operations.CancelOperation rpc."
-    },
-    "v1CheckAccountsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "accountIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. A comma-separated list of account ids. For example, you set to [\"accountId1\",\"accountId2\",\"accountId3\"]."
-        }
-      }
     },
     "v1CheckAccountsResponse": {
       "type": "object",
@@ -19741,6 +20138,7 @@
         "criteria": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1Criteria"
           },
           "description": "Required. Criteria for the adjustment to be applied."
@@ -19748,6 +20146,7 @@
         "allocator": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1Allocator"
           }
         },
@@ -19756,42 +20155,6 @@
         },
         "updateTime": {
           "type": "string"
-        }
-      }
-    },
-    "v1CostAllocatorRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "expiration": {
-          "type": "string",
-          "format": "int64"
-        },
-        "startMonth": {
-          "type": "string",
-          "description": "Optional. The starting month of the allocator to be effective."
-        },
-        "defaultAccount": {
-          "type": "string",
-          "description": "Optional. The default account for remaining costs. If not set, will allocate the cost to the original account."
-        },
-        "criteria": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Criteria"
-          },
-          "description": "Required. Criteria for the adjustment to be applied."
-        },
-        "allocator": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Allocator"
-          }
         }
       }
     },
@@ -19853,45 +20216,6 @@
       },
       "description": "Request message for the CreateAccountAccessStackset rpc."
     },
-    "v1CreateAccountBudgetAlertsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "id": {
-          "type": "string",
-          "title": "Required. Account Id"
-        },
-        "budgetAlert": {
-          "$ref": "#/definitions/apiwaveBudgetAlert",
-          "description": "Required. Budget alert setting."
-        }
-      },
-      "title": "Request message for CreateAccountBudgetAlerts"
-    },
-    "v1CreateAccountBudgetRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "level": {
-          "type": "string",
-          "title": "Required. 'account' or 'acctgroup'"
-        },
-        "id": {
-          "type": "string",
-          "title": "Required. Account or AccountGroup Id"
-        },
-        "data": {
-          "$ref": "#/definitions/blueapiapiBudget"
-        }
-      },
-      "title": "Request message for CreateAccountBudget"
-    },
     "v1CreateAccountBudgetResponse": {
       "type": "object",
       "properties": {
@@ -19902,64 +20226,18 @@
       },
       "title": "Response message for CreateAccountBudget"
     },
-    "v1CreateAccountInvoiceServiceDiscountsRequest": {
-      "type": "object",
-      "properties": {
-        "groupId": {
-          "type": "string",
-          "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1AccountServiceDiscounts"
-          },
-          "description": "Required."
-        }
-      },
-      "description": "Request message for the CreateAccountInvoiceServiceDiscounts rpc."
-    },
     "v1CreateAccountInvoiceServiceDiscountsResponse": {
       "type": "object",
       "properties": {
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1AccountServiceDiscounts"
           }
         }
       },
       "description": "Response message for the CreateAccountInvoiceServiceDiscounts rpc."
-    },
-    "v1CreateAccountRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "id": {
-          "type": "string",
-          "description": "Required. The account id to register."
-        },
-        "name": {
-          "type": "string",
-          "description": "Optional. If empty, set to the value of `id`."
-        },
-        "parent": {
-          "type": "string",
-          "description": "Optional. The parent `billingInternalId` of the billing group to which this account will belong to."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CreateAccountRequestAwsOptions",
-          "description": "Required for the `aws` vendor. AWS-specific options."
-        },
-        "gcpOptions": {
-          "$ref": "#/definitions/v1CreateAccountRequestGcpOptions",
-          "description": "Required for the `gcp` vendor. GCP-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CreateAccount rpc."
     },
     "v1CreateAccountRequestAwsOptions": {
       "type": "object",
@@ -19984,30 +20262,6 @@
         }
       },
       "description": "GCP-specific options for registering an account."
-    },
-    "v1CreateAdjustmentConfigRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "config": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiConfigFilters"
-          },
-          "description": "Required. \nA list of filtering options. See [api.ConfigFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiManagementAccount"
-          },
-          "description": "Optional."
-        }
-      },
-      "description": "Request message for the Billing.CreateAdjustmentConfig rpc."
     },
     "v1CreateAlertRequest": {
       "type": "object",
@@ -20077,6 +20331,7 @@
         "criteria": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1Criteria"
           },
           "description": "Required. Criteria for the adjustment to be applied."
@@ -20084,6 +20339,7 @@
         "allocator": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1Allocator"
           }
         }
@@ -20329,70 +20585,20 @@
         }
       }
     },
-    "v1CreateCalculationsScheduleRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "schedule": {
-          "type": "string",
-          "description": "Required. The desired schedule in UTC, using the unix-cron string format `* * * * *` which is a set of five fields in a line using the order: `minute hour day-of-the-month month day-of-the-week`.\n\n* `minute` values can be `0-59`\n* `hour` values can be `0-23`\n* `day-of-the-month` values can be `1-31`\n* `month` values can be `1-12`, or `JAN-DEC`\n* `day-of-the-week` values can be `0-6`, or `SUN-SAT`, or `7` for Sunday\n\nSpecial characters:\n* A field can contain an asterisk (*), which always stands for \"first-last\".\n* Ranges are two numbers separated with a hyphen (-) and the specified range is inclusive.\n* Following a range with `/NUMBER` specifies skips of the number's value through the range. For example, both `0-23/2` and `*/2` can be used in the `hour` field to specify execution every two hours.\n* A list is a set of numbers (or ranges) separated by commas (,). For example, `1,2,5,6` in the `month` field specifies an execution on the first, second, fifth, and sixth days of the month."
-        },
-        "scheduleMacro": {
-          "type": "string",
-          "description": "Optional. Non-standard macro(s) that augment(s) `schedule`'s behavior. The only supported value for now is `@endofmonth`.\n\n`@endofmonth` - If set, the backend scheduler will only use the `minute` and `hour` part of `schedule`'s value and set the days to 28th, 29th, 30th, and 31st but the runner will do the filtering for the actual end of the trigger month. Note that this is different than setting `schedule` to, say, `0 0 28-31 * *`."
-        },
-        "targetMonth": {
-          "type": "string",
-          "description": "Optional. The desired month to calculate. If not set, defaults to previous month. The only supported value for now is `@current`.\n\n`@current` - If set, calculate for the month the schedule is triggered (or current month)."
-        },
-        "notificationChannel": {
-          "type": "string",
-          "description": "Optional. The channel id to use for notifications. At the moment, only email-type notification channels are supported. If not set, your default channel will be used. And if non-existent, an email-type notification channel will be created using your primary email address."
-        },
-        "force": {
-          "type": "boolean",
-          "description": "Optional. Not used at the moment."
-        },
-        "dryRun": {
-          "type": "boolean",
-          "description": "Optional. If set to true, skips the actual calculations. Useful as test, or reminder."
-        }
-      },
-      "description": "Request message for the Cost.CreateCalculationsSchedule rpc."
-    },
-    "v1CreateCalculatorCostModifierRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CalculatorCostModifierAwsOptions",
-          "description": "Required if `{vendor}` is `aws`. AWS-specific options."
-        },
-        "azureOptions": {
-          "$ref": "#/definitions/v1CalculatorCostModifierAzureOptions",
-          "description": "Required if `{vendor}` is `azure`. Azure-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CreateCalculatorCostModifier rpc."
-    },
     "v1CreateCalculatorCostModifierResponse": {
       "type": "object",
       "properties": {
         "aws": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1CalculatorCostModifier"
           }
         },
         "azure": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1CalculatorCostModifier"
           }
         }
@@ -20435,32 +20641,6 @@
         }
       },
       "description": "Request message for the Admin.CreateCloudWatchMetricsStream rpc."
-    },
-    "v1CreateCostFiltersRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "filterName": {
-          "type": "string",
-          "title": "Required. Filter Name. Specify characters between 1 ~ 100"
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Required. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-          "description": "Required. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the CreateCostFilters rpc."
     },
     "v1CreateCostFiltersResponse": {
       "type": "object",
@@ -20610,31 +20790,6 @@
         }
       },
       "description": "Request message for the Iam.CreateIdentityProvider rpc."
-    },
-    "v1CreateInvoiceRequest": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string",
-          "description": "Required. Month to get invoice. Format: `yyyymm`."
-        },
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "allGroups": {
-          "type": "boolean",
-          "description": "Optional. You can set all billing groups.\n\nIf this parameter is not set, The list set to `groups` is used."
-        },
-        "groups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "title": "Optional. You can set it to a list of billing internal group id"
-        }
-      },
-      "description": "Request message for the CreateInvoice rpc."
     },
     "v1CreateIpFilterRequest": {
       "type": "object",
@@ -20801,30 +20956,6 @@
       },
       "description": "Response message for the Organization.CreateOrg rpc."
     },
-    "v1CreatePartnerTokenRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. Partner id or audience for the token."
-        }
-      },
-      "description": "Request message for the Iam.CreatePartnerToken rpc."
-    },
-    "v1CreatePayerAccountRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1CreatePayerAccountRequestAwsOptions",
-          "description": "Required for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.CreatePayerAccount rpc."
-    },
     "v1CreatePayerAccountRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -20933,6 +21064,7 @@
         "waveConfig": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleResellerConfig"
           },
           "title": "Optional. Feature Config. If not set config value, use default config"
@@ -20940,6 +21072,7 @@
         "aquaConfig": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleResellerConfig"
           },
           "title": "Optional. Feature Config. If not set config value, use default config"
@@ -21000,6 +21133,7 @@
         "roles": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1MapRole"
           },
           "description": "Required. The roles to map to the user. Limited to 5 items."
@@ -21084,7 +21218,7 @@
       "properties": {
         "target": {
           "type": "string",
-          "title": "Project Id for GCP, Account Id for Azure"
+          "title": "Billing Id for GCP, Account Id for Azure"
         },
         "orgId": {
           "type": "string",
@@ -21241,6 +21375,7 @@
         "costGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverAlertCostGroup"
           }
         },
@@ -21251,14 +21386,6 @@
           "$ref": "#/definitions/coverAlertChannels"
         },
         "name": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ExecuteOptimizationRequest": {
-      "type": "object",
-      "properties": {
-        "recommendationId": {
           "type": "string"
         }
       }
@@ -21284,40 +21411,6 @@
       },
       "description": "Request message for the ExportAuditLogs rpc."
     },
-    "v1ExportCostFiltersFileRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "filterId": {
-          "type": "string",
-          "description": "Required. Filter Id."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmd`."
-        },
-        "groupByMonth": {
-          "type": "boolean",
-          "description": "Optional. If set to true, return data grouped by month within the date range. If you want data that is grouped per account per month, set this to `true`, then set `groupByColumns` to `none`."
-        },
-        "groupByColumns": {
-          "type": "string",
-          "description": "Optional. A comma-separated list of columns to aggregate the data into. Valid values are `productCode`, `serviceCode`, `region`, `zone`, `usageType`, `instanceType`, `operation`, `invoiceId`, `description`, and `resourceId`. A special value of `none` is also supported, which means query by date or month per account only.\n\nFor example, if you only want the services and region data, you can set this field to `productCode,region`. Your input sequence doesn't matter (although the sequence above is recommended) as the actual sequence is already fixed in the return data (see the definition in https://github.com/alphauslabs/blueapi/blob/main/api/aws/cost.proto), which is generic to specific, top to bottom. Invalid values are discarded. Excluded columns will be empty."
-        },
-        "includeTags": {
-          "type": "boolean",
-          "description": "Optional. If set to true, stream will include resource tags."
-        }
-      },
-      "description": "Request message for the ExportCostFiltersFile rpc."
-    },
     "v1ExportCostFiltersFileResponse": {
       "type": "object",
       "properties": {
@@ -21327,20 +21420,6 @@
         }
       },
       "description": "Response message for the ExportCostFiltersFile rpc."
-    },
-    "v1ExportInvoiceFileRequest": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string",
-          "description": "Required. Month to get invoice. Format: `yyyymm`."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group or a comma-separated list of groups. ex) `group1,group2`. if want to set all group, set `*`. \n\nImplied as the parent billing group for Wave(Pro) users."
-        }
-      },
-      "description": "Request message for the ExportCostFiltersFile rpc."
     },
     "v1ExportInvoiceFileResponse": {
       "type": "object",
@@ -21483,6 +21562,7 @@
         "summary": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1AssetsSummary"
           }
         },
@@ -21507,6 +21587,7 @@
         "yearMonth": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleYearMonth"
           },
           "description": "List of available yearmonth."
@@ -21572,6 +21653,7 @@
         "category": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCategory"
           }
         }
@@ -21633,6 +21715,7 @@
         "items": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/costv1CostAttribute"
           },
           "description": "The cost attributes."
@@ -21681,12 +21764,14 @@
         "result": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverResult"
           }
         },
         "tagData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverTagData"
           }
         }
@@ -21724,71 +21809,12 @@
         "costGroupData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverCostGroupData"
           }
         }
       },
       "title": "Response message for GetCostGroups"
-    },
-    "v1GetCostReductionRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "orgId": {
-          "type": "string",
-          "description": "Required. Organization Id."
-        },
-        "reductionDisplay": {
-          "type": "string",
-          "title": "Required. Valid values: 'all', 'reservation', 'savingsplan'"
-        },
-        "includeDetails": {
-          "type": "boolean",
-          "description": "Optional. If set to \"true\", details of the RI or SP list is returned. Default: false."
-        },
-        "fromDate": {
-          "type": "string",
-          "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
-        },
-        "toDate": {
-          "type": "string",
-          "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
-        },
-        "payerId": {
-          "type": "string",
-          "description": "Optional. Payer Id."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Optional. Billing group Id."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. Account group Id."
-        },
-        "costGroupId": {
-          "type": "string",
-          "description": "Optional. Cost Group Id used in octo."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of Account Ids."
-        },
-        "services": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of services."
-        }
-      },
-      "title": "Request message for GetCostReduction"
     },
     "v1GetCostReductionResponse": {
       "type": "object",
@@ -21878,6 +21904,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestOptionsFilters] for more information on each filter item. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21885,6 +21912,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options specific for tags. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc. Discarded when `groupByColumns` field is set or if `groupByMonth` is true."
@@ -21905,6 +21933,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestOptionsFilters] for more information on each filter item. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21912,6 +21941,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options specific for tags. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21932,6 +21962,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestOptionsFilters] for more information on each filter item. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21939,6 +21970,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options specific for tags. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21959,6 +21991,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestOptionsFilters] for more information on each filter item. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21979,6 +22012,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestOptionsFilters] for more information on each filter item. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21986,6 +22020,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           },
           "description": "Optional. A list of filtering options specific for tags. \nMultiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -21993,72 +22028,18 @@
         "labelFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           }
         },
         "projectLabelFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestOptionsFilters"
           }
         }
       }
-    },
-    "v1GetCoverageOndemandRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "orgId": {
-          "type": "string",
-          "description": "Required. Organization Id."
-        },
-        "period": {
-          "type": "string",
-          "title": "Required. Available values: day, hour"
-        },
-        "fromDate": {
-          "type": "string",
-          "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
-        },
-        "toDate": {
-          "type": "string",
-          "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
-        },
-        "payerId": {
-          "type": "string",
-          "description": "Optional. Payer Id."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Optional. Billing group Id."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. Account group Id."
-        },
-        "costGroupId": {
-          "type": "string",
-          "title": "Optional. Cost Group Id, currently used in octo"
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of Account Ids."
-        },
-        "services": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of services."
-        }
-      },
-      "title": "Request message for GetCoverageOndemand"
     },
     "v1GetCoverageOndemandResponse": {
       "type": "object",
@@ -22069,67 +22050,12 @@
         "ondemandData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiOndemandData"
           }
         }
       },
       "title": "Response message for GetCoverageOndemand"
-    },
-    "v1GetCoverageOptionsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "orgId": {
-          "type": "string",
-          "description": "Required. Organization Id."
-        },
-        "period": {
-          "type": "string",
-          "description": "Required. Available values: day, hour."
-        },
-        "fromDate": {
-          "type": "string",
-          "description": "Optional. The start date of the displayed data. If not set, the first day of the current month will be used. Format: yyyy-mm-dd."
-        },
-        "toDate": {
-          "type": "string",
-          "description": "Optional. The end date of the displayed data. If not set, current date will be used. Format: yyyy-mm-dd."
-        },
-        "payerId": {
-          "type": "string",
-          "description": "Optional. Payer Id."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Optional. Billing group Id."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. Account group Id."
-        },
-        "costGroupId": {
-          "type": "string",
-          "title": "Optional. Cost Group Id"
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of Account Ids."
-        },
-        "services": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. List of services."
-        }
-      },
-      "title": "Request message for GetCoverageOptions"
     },
     "v1GetCoverageOptionsResponse": {
       "type": "object",
@@ -22140,6 +22066,7 @@
         "optionsData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiOptionsData"
           }
         }
@@ -22257,6 +22184,7 @@
         "favorites": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverFavorites"
           }
         }
@@ -22281,26 +22209,13 @@
       },
       "description": "Response message for the Pricing.GetInfo rpc."
     },
-    "v1GetInvoiceRequest": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string",
-          "description": "Required. Month to get invoice. Format: `yyyymm`."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
-        }
-      },
-      "description": "Request message for the Cost.GetInvoiceRequest rpc."
-    },
     "v1GetMemberCostGroupResponse": {
       "type": "object",
       "properties": {
         "costGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverMemberCostGroup"
           }
         }
@@ -22322,6 +22237,7 @@
         "userData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverUserData"
           }
         }
@@ -22337,6 +22253,7 @@
         "data": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiMonthOnMonthCostForecast"
           }
         },
@@ -22359,6 +22276,7 @@
         "data": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiMonthToDateCostForecast"
           }
         },
@@ -22377,6 +22295,7 @@
         "data": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiMonthlyCostForecast"
           }
         },
@@ -22424,6 +22343,7 @@
         "reports": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ProformaReports"
           }
         }
@@ -22449,35 +22369,6 @@
           "$ref": "#/definitions/coverAWSRecommendations"
         }
       }
-    },
-    "v1GetRecommendationsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "orgId": {
-          "type": "string",
-          "description": "Required. Organization Id."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. List of Account Ids."
-        },
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. For OCTO only."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1GetRecommendationsRequestAwsOptions",
-          "title": "Required if vendor = 'aws'"
-        }
-      },
-      "title": "Request message for GetRecommendations"
     },
     "v1GetRecommendationsRequestAwsOptions": {
       "type": "object",
@@ -22584,6 +22475,7 @@
         "resource": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverResourceData"
           }
         }
@@ -22608,6 +22500,7 @@
         "tagData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverTagData"
           }
         }
@@ -22640,6 +22533,7 @@
         "utilizationData": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiUtilizationData"
           }
         }
@@ -22652,6 +22546,7 @@
         "viewList": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverViewList"
           }
         }
@@ -22763,21 +22658,12 @@
         "accountGroups": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiAccountGroup"
           }
         }
       },
       "description": "Response message for the Admin.ListAccountGroups rpc."
-    },
-    "v1ListAccountInvoiceServiceDiscountsRequest": {
-      "type": "object",
-      "properties": {
-        "groupId": {
-          "type": "string",
-          "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
-        }
-      },
-      "description": "Request message for the ListAccountInvoiceServiceDiscounts rpc."
     },
     "v1ListAccountUsageRequest": {
       "type": "object",
@@ -22824,6 +22710,7 @@
         "awsOptions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ListAssetsFilters"
           },
           "description": "Optional. For AWS-specific filter options."
@@ -22831,6 +22718,7 @@
         "awsPropertiesOptions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ListAssetsFilters"
           },
           "description": "Optional. For AWS-specific properties filter options."
@@ -22879,6 +22767,7 @@
         "operations": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protosOperation"
           }
         }
@@ -22900,25 +22789,12 @@
         "schedules": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1CalculationsSchedule"
           }
         }
       },
       "description": "Response message for the Cost.ListCalculationsSchedules rpc."
-    },
-    "v1ListCalculatorRunningAccountsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "month": {
-          "type": "string",
-          "description": "Optional. The UTC month to query. Defaults to current month if empty. Format is `yyyymm`. For example, June 2021 will be `202106`."
-        }
-      },
-      "description": "Request message for the Cost.ListCalculatorRunningAccounts rpc."
     },
     "v1ListCalculatorRunningAccountsResponse": {
       "type": "object",
@@ -22930,36 +22806,6 @@
       },
       "description": "Response message for the Cost.ListCalculatorRunningAccounts rpc."
     },
-    "v1ListCostFilters": {
-      "type": "object",
-      "properties": {
-        "filterId": {
-          "type": "string",
-          "description": "Required. Filter Id."
-        },
-        "filterName": {
-          "type": "string",
-          "description": "Required. Filter Name."
-        },
-        "vendor": {
-          "type": "string",
-          "description": "Required. Vendor."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Response message for the ListCostFilters rpc."
-    },
     "v1ListCostFiltersResponse": {
       "type": "object",
       "properties": {
@@ -22967,7 +22813,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1ListCostFilters"
+            "$ref": "#/definitions/costv1ListCostFilters"
           }
         }
       },
@@ -22987,6 +22833,7 @@
         "billingGroup": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/rippleBillingGroupExchangeRate"
           },
           "description": "The billing group exchange rate."
@@ -23013,6 +22860,7 @@
         "data": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ListIdentityProvidersResponseIdentityProvider"
           }
         }
@@ -23055,22 +22903,13 @@
       "type": "object",
       "description": "Request message for the ListInvoiceServiceDiscounts rpc."
     },
-    "v1ListInvoiceStatusRequest": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string",
-          "description": "Required. Month to get invoice status. Format: `yyyymm`."
-        }
-      },
-      "description": "Request message for the ListInvoiceStatus rpc."
-    },
     "v1ListNotificationChannelsResponse": {
       "type": "object",
       "properties": {
         "channels": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiNotificationChannel"
           }
         }
@@ -23083,6 +22922,7 @@
         "notifications": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/blueapiapiNotification"
           }
         }
@@ -23095,6 +22935,7 @@
         "permissions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiPermission"
           }
         }
@@ -23179,29 +23020,12 @@
         "roles": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiRole"
           }
         }
       },
       "description": "Response message for the Iam.ListRoles rpc."
-    },
-    "v1ListUsageCostsDriftRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Optional. If empty, returns all billing groups."
-        },
-        "month": {
-          "type": "string",
-          "description": "Optional. If empty, defaults to current UTC month. Format: yyyymm."
-        }
-      },
-      "description": "Request message for the Billing.ListUsageCostsDrift rpc."
     },
     "v1ListUserRoleMappingsResponse": {
       "type": "object",
@@ -23209,6 +23033,7 @@
         "userRoleMappings": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiUserRoleMapping"
           }
         }
@@ -23241,6 +23066,7 @@
         "users": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1MFAUser"
           }
         }
@@ -23271,32 +23097,6 @@
     },
     "v1MarkAsExecutedResponse": {
       "type": "object"
-    },
-    "v1ModifyResourceTypeRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. Cloud vendor."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required. Account Id."
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "Required. The resource Id."
-        },
-        "resourceType": {
-          "type": "string",
-          "description": "Required. The recommended resource type."
-        },
-        "region": {
-          "type": "string",
-          "description": "Required. Resource region."
-        }
-      },
-      "title": "Request message for ModifyResourceType"
     },
     "v1ModifyResourceTypeResponse": {
       "type": "object",
@@ -23349,6 +23149,7 @@
         "executedRecommendationDetails": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverExecutedRecommendationDetails"
           }
         }
@@ -23488,36 +23289,6 @@
       },
       "title": "Response message for PublishView"
     },
-    "v1ReadAdjustmentsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` or `azure` is supported."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. At the moment, only billing internal ids are supported. If set, reads the non-usage-based adjustment details of this group. Valid only if `accountId` is not set. If both `groupId` and `accountId` are not set, reads the adjustment details of the whole organization. Only valid for Ripple users. Implied (or discarded) for Wave(Pro) users."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Optional. If set, reads the non-usaged-based adjustment details of this account. Also invalidates the `groupId` value even if set. If both `groupId` and `accountId` are not set, reads the adjustment details of the whole organization."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadAdjustmentsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadAdjustments rpc."
-    },
     "v1ReadAdjustmentsRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -23537,36 +23308,6 @@
       },
       "description": "Request message for the ReadBudgetAlerts rpc."
     },
-    "v1ReadCostAttributesRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. If set, reads the cost attributes of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the cost attributes of the whole organization. Optional for AWS Wave(Pro)."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the cost attributes of the whole organization."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadCostAttributesRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadCostAttributes rpc."
-    },
     "v1ReadCostAttributesRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -23575,44 +23316,6 @@
           "description": "Optional. A comma-separated list of dimensions to query. Valid values are `productCode`, `serviceCode`, `region`, `zone`, `usageType`, `instanceType`, `operation`, `invoiceId`, `description`, `resourceId`, `tags`, and `costCategories`. Sequence doesn't matter. An empty value implies all attributes will be returned."
         }
       }
-    },
-    "v1ReadCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. Supported vendors are `aws`,`azure` and `gcp`."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Optional. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Optional. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. The UTC date to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        },
-        "gcpOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestGcpOptions",
-          "description": "Optional. Valid only for the `gcp` vendor. GCP-specific options."
-        },
-        "azureOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestAzureOptions",
-          "description": "Optional. Valid only for the `azure` vendor. Azure-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadCosts rpc."
     },
     "v1ReadCostsRequestAwsOptions": {
       "type": "object",
@@ -23632,6 +23335,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestAwsOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestAwsOptionsFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -23639,6 +23343,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestAwsOptionsTagFilters"
           },
           "description": "Optional. A list of filtering options specific for tags. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc. Discarded when `groupByColumns` field is set or if `groupByMonth` is true."
@@ -23734,6 +23439,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestGcpOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestGcpOptionsFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -23781,84 +23487,6 @@
       },
       "description": "A map of \"key:value\" column filters. Dependent on `groupByColumns` and/or `groupByMonth`. The key indicates the column name while the value is the filter value prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you like to filter `productCode` to return only `AmazonEC2`, set to `{\"productCode\":\"eq:AmazonEC2\"}` or `{\"productCode\":\"AmazonEC2\"}`. You can also use a regular expression like `{\"productCode\":\"re:AmazonEC2|AmazonRDS\"}`, which means return all AmazonEC2 or AmazonRDS lineitems. Or reverse regexp, such as `{\"productCode\":\"!re:^AmazonEC2$\"}`, which means return all items except `AmazonEC2`."
     },
-    "v1ReadInvoiceAdjustmentsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws`,`azure`,`gcp` is supported."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required."
-        },
-        "month": {
-          "type": "string",
-          "description": "Optional. The UTC month to query. If empty, defaults to current month. Format is `yyyymm`. For example, June 2021 will be `202106`."
-        },
-        "feeType": {
-          "type": "string",
-          "description": "Optional. If empty, defaults to all fee type. At the moment, only `Fee`,`Refund`,`Credit`,`SppDiscount`,`EdpDiscount`,`BundledDiscount` is supported."
-        }
-      },
-      "description": "Request message for the Billing.ReadInvoiceAdjustments rpc."
-    },
-    "v1ReadNonTagCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Required. The billing internal id to stream."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-        },
-        "groupByMonths": {
-          "type": "boolean",
-          "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`. If not set, daily data will be returned."
-        }
-      },
-      "description": "Request message for the Cost.ReadNonTagCosts rpc."
-    },
-    "v1ReadTagCostsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "billingInternalId": {
-          "type": "string",
-          "description": "Required. The billing internal id to stream."
-        },
-        "startTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`."
-        },
-        "endTime": {
-          "type": "string",
-          "description": "Optional. Timestamp to end the streaming data. If not set, current date will be used. Format: `yyyymmdd`."
-        },
-        "groupByMonths": {
-          "type": "boolean",
-          "description": "Optional. Group services and costs by months in the range of `startTime` and `endTime`. If not set, daily data will be returned."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadTagCostsRequestAwsOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the Cost.ReadTagCosts rpc."
-    },
     "v1ReadTagCostsRequestAwsOptions": {
       "type": "object",
       "properties": {
@@ -23877,6 +23505,7 @@
         "filters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadCostsRequestAwsOptionsFilters"
           },
           "description": "Optional. A list of filtering options. See [ReadCostsRequestAwsOptionsFilters] for more information on each filter item. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc."
@@ -23884,6 +23513,7 @@
         "tagFilters": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1ReadTagCostsRequestAwsOptionsTagFilters"
           },
           "description": "Optional. A list of filtering options specific for tags. Multiple filter items will use the logical 'or' operator, e.g. filter1 || filter2 || filter3, etc. Discarded when `groupByColumns` field is set or if `groupByMonth` is true."
@@ -23929,58 +23559,6 @@
       },
       "description": "A map of \"key:value\" tag filters. The key indicates the tag key while the value is the filter tag value which can be prefixed by either \"eq:\" (equal), \"re:\" (regular expressions based on https://github.com/google/re2), or \"!re:\" (reverse \"re:\"). No prefix is the same as \"eq:\". Multiple map items will use the logical 'and' operator, e.g. mapfilter1 \u0026\u0026 mapfilter2 \u0026\u0026 mapfilter3, etc.\n\nFor example, if you want to query lineitems with the tag `project:MY_PROJECT`, set to `{\"project\":\"MY_PROJECT\"}`. You can also use regular expressions for tag values, such as `{\"name\":\"re:[A-Za-z0-9]*\"}`."
     },
-    "v1ReadUntaggedGroupsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported.",
-          "required": [
-            "vendor"
-          ]
-        },
-        "fieldMask": {
-          "type": "string",
-          "description": "Optional. Get only the value that set fieldMask.\n\nsee more info: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto"
-        }
-      },
-      "description": "Request message for the Billing.ReadUntaggedGroups rpc.",
-      "required": [
-        "vendor"
-      ]
-    },
-    "v1RefreshPartnerTokenRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. Partner id or audience for the token."
-        },
-        "token": {
-          "type": "string",
-          "description": "Required. The previous (old) token to be refreshed."
-        }
-      },
-      "description": "Request message for the Iam.RefreshPartnerToken rpc."
-    },
-    "v1RegisterAccountRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. Cloud vendor."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required. The AWS account Id."
-        },
-        "accountName": {
-          "type": "string",
-          "title": "The account name"
-        }
-      },
-      "description": "Request message for the RegisterAccount rpc."
-    },
     "v1RegisterAccounts": {
       "type": "object",
       "properties": {
@@ -24004,7 +23582,7 @@
         },
         "target": {
           "type": "string",
-          "title": "Project Id for GCP, Account Id for Azure"
+          "title": "Billing Id for GCP, Account Id for Azure"
         },
         "accountType": {
           "type": "string",
@@ -24067,36 +23645,6 @@
         }
       }
     },
-    "v1RemoveAccountInvoiceServiceDiscountsRequest": {
-      "type": "object",
-      "properties": {
-        "groupId": {
-          "type": "string",
-          "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1AccountServiceDiscounts"
-          },
-          "description": "Required."
-        }
-      }
-    },
-    "v1RemoveCostGroupMemberRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "userId": {
-          "type": "string",
-          "description": "Required. User Id."
-        }
-      },
-      "title": "Request message for RemoveCostGroupMember"
-    },
     "v1RemoveCostGroupMemberResponse": {
       "type": "object",
       "properties": {
@@ -24127,19 +23675,6 @@
         }
       },
       "title": "Response message for RemoveFavorite"
-    },
-    "v1RemoveSideMenuFavoriteRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string",
-          "description": "Required. View Id."
-        },
-        "menuItemId": {
-          "type": "string"
-        }
-      },
-      "title": "Request message for RemoveSideMenuFavorite"
     },
     "v1RemoveSideMenuFavoriteResponse": {
       "type": "object",
@@ -24218,6 +23753,7 @@
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apicoverAccount"
           }
         }
@@ -24387,29 +23923,6 @@
       },
       "description": "Response message for ListSavings, RestoreSavings, SimulateSavings rpc."
     },
-    "v1SetCostGroupAnomalyOptionsRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "threshold": {
-          "type": "number",
-          "format": "float",
-          "title": "Required"
-        },
-        "isPercentage": {
-          "type": "boolean",
-          "description": "Required. When set to true, the threshold is a percentage to the actual cost. Otherwise, it is a fixed amount."
-        },
-        "pastDataInMonths": {
-          "type": "string",
-          "format": "int64",
-          "description": "Optional. The number of past months to be used in training the model. Note: This will affect the results of anomaly detection. Default and max is 9 while min is 1."
-        }
-      }
-    },
     "v1SetCostGroupAnomalyOptionsResponse": {
       "type": "object",
       "properties": {
@@ -24418,19 +23931,6 @@
         },
         "anomalyOptions": {
           "$ref": "#/definitions/coverAnomalyOptions"
-        }
-      }
-    },
-    "v1SetCostGroupEventIndicatorRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "anomaly": {
-          "type": "boolean",
-          "title": "Required. Only anomaly is supported as of now"
         }
       }
     },
@@ -24461,28 +23961,6 @@
           "type": "string"
         }
       }
-    },
-    "v1TerminateResourceRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. Cloud vendor."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required. Account Id."
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "Required. The resource Id."
-        },
-        "region": {
-          "type": "string",
-          "description": "Required. Resource region."
-        }
-      },
-      "title": "Request message for TerminateResource"
     },
     "v1TerminateResourceResponse": {
       "type": "object",
@@ -24521,177 +23999,18 @@
     "v1UndoExecutedRecommendationResponse": {
       "type": "object"
     },
-    "v1UpdateAccessGroupRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. access group id."
-        },
-        "name": {
-          "type": "string",
-          "description": "Optional. access group name. Set only the name to be changed.\n\nWe recommend the name length of 1~60 characters."
-        },
-        "description": {
-          "type": "string",
-          "description": "Optional. access group description. Set only the description to be changed.\n\nWe recommend the description length of 0~150 characters."
-        },
-        "billingGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. Billing group to be included in the access group.\n\nYou can only include billing groups with the same calculation type and currency type.\nSet only the billingGroups to be changed.\nSpecify the billingInternalIds. For example: [`billingInternalId1`,`billingInternalId2`,`billingInternalId3`]"
-        }
-      },
-      "description": "Request message for the UpdateAccessGroup rpc."
-    },
-    "v1UpdateAccountBudgetAlertsRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "id": {
-          "type": "string",
-          "title": "Required. Account Id"
-        },
-        "budgetAlert": {
-          "$ref": "#/definitions/apiwaveBudgetAlert",
-          "description": "Required. Budget alert setting.\n\nSet only the setting value to be changed.\nFor example, If you want to change only daily value, set `{\"budget\":[{\"id\":\"daily\",\"value\":100,\"enabled\":true}}` as a parameter\nThe same goes for notification. If you want to change only email value, set `{\"notification\":[{\"id\":\"email\",\"destination\":\"budgetalert-example@alphaus.cloud\",\"enabled\":true}}` as a parameter"
-        }
-      },
-      "title": "Request message for UpdateAccountBudgetAlerts"
-    },
-    "v1UpdateAccountBudgetRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "budgetId": {
-          "type": "string",
-          "title": "Required. Budget Id"
-        },
-        "data": {
-          "$ref": "#/definitions/blueapiapiBudget"
-        }
-      },
-      "title": "Request message for UpdateAccountBudget"
-    },
-    "v1UpdateAccountInvoiceServiceDiscountsRequest": {
-      "type": "object",
-      "properties": {
-        "groupId": {
-          "type": "string",
-          "description": "Required.\n\nFor Ripple, only billing internal ids are supported at the moment. You can set it to a single group\n\nImplied as the parent billing group for Wave(Pro) users."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1AccountServiceDiscounts"
-          },
-          "description": "Required."
-        }
-      },
-      "description": "Request message for the UpdateAccountInvoiceServiceDiscounts rpc."
-    },
     "v1UpdateAccountInvoiceServiceDiscountsResponse": {
       "type": "object",
       "properties": {
         "accounts": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1AccountServiceDiscounts"
           }
         }
       },
       "description": "Response message for the UpdateAccountInvoiceServiceDiscounts rpc."
-    },
-    "v1UpdateAccountRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required."
-        },
-        "id": {
-          "type": "string",
-          "description": "Required."
-        },
-        "name": {
-          "type": "string",
-          "description": "Optional."
-        }
-      },
-      "description": "Request message for the Cost.UpdateAccount rpc."
-    },
-    "v1UpdateAdjustmentConfigRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "config": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiConfigFilters"
-          },
-          "description": "Optional."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiManagementAccount"
-          },
-          "description": "Optional."
-        }
-      },
-      "description": "Request message for the Billing.UpdateAdjustmentConfig rpc."
-    },
-    "v1UpdateAlertDetailsRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. Alert ID."
-        },
-        "name": {
-          "type": "string",
-          "description": "If optional fields are not supplied, no changes occur.\nOptional."
-        },
-        "fixedAmount": {
-          "type": "number",
-          "format": "float",
-          "description": "Both are optional."
-        },
-        "percentage": {
-          "type": "number",
-          "format": "float"
-        },
-        "granularity": {
-          "type": "string",
-          "description": "Optional. daily or monthly. Only 'daily' is supported for now."
-        },
-        "costGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. Cost group IDs."
-        },
-        "channels": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. Channel IDs."
-        }
-      },
-      "title": "Request message for UpdateAlertDetails"
     },
     "v1UpdateAlertDetailsResponse": {
       "type": "object",
@@ -24702,87 +24021,6 @@
       },
       "title": "Response message for UpdateAlertDetails"
     },
-    "v1UpdateAnomalyAlertRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "title": "required. Id"
-        },
-        "name": {
-          "type": "string",
-          "title": "required. alert name"
-        },
-        "alertEnabled": {
-          "type": "boolean",
-          "description": "required."
-        },
-        "notificationChannels": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "required. Notification Channel Ids."
-        },
-        "frequency": {
-          "type": "string",
-          "description": "required. Frequency."
-        },
-        "costGroupId": {
-          "type": "string",
-          "title": "required. cost group id"
-        }
-      }
-    },
-    "v1UpdateBudgetAlertsRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "title": "Required. budget alert id"
-        },
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "accounts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. Lsit of accountId. For example, you set to [\"accountId1\",\"accountId2\",\"accountId3\"]."
-        },
-        "notification": {
-          "$ref": "#/definitions/apiBudgetAlertNotification",
-          "description": "Required."
-        },
-        "daily": {
-          "$ref": "#/definitions/apiDailyBudgetAlert",
-          "description": "Optional."
-        },
-        "dailyRate": {
-          "$ref": "#/definitions/apiDailyRateIncreaseBudgetAlert",
-          "description": "Optional."
-        },
-        "monthly": {
-          "$ref": "#/definitions/apiMonthlyBudgetAlert",
-          "description": "Optional."
-        }
-      },
-      "description": "Request message for the UpdateBudgetAlerts rpc."
-    },
-    "v1UpdateBudgetRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. Budget ID."
-        },
-        "budgetData": {
-          "$ref": "#/definitions/coverBudgetData"
-        }
-      }
-    },
     "v1UpdateBudgetResponse": {
       "type": "object",
       "properties": {
@@ -24790,28 +24028,6 @@
           "$ref": "#/definitions/coverBudgetData"
         }
       }
-    },
-    "v1UpdateChannelDetailsRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. Channel ID."
-        },
-        "name": {
-          "type": "string",
-          "title": "If optional fields are not supplied, no changes occur.\nOptional. Either actual email address or slack/msteams channel name"
-        },
-        "type": {
-          "type": "string",
-          "description": "Optional. email, slack, or msteams."
-        },
-        "webhookUrl": {
-          "type": "string",
-          "description": "Optional. Only needed for slack and msteams type."
-        }
-      },
-      "title": "Request message for UpdateChannelDetails"
     },
     "v1UpdateChannelDetailsResponse": {
       "type": "object",
@@ -24821,36 +24037,6 @@
         }
       },
       "title": "Response message for UpdateChannelDetails"
-    },
-    "v1UpdateCostFiltersRequest": {
-      "type": "object",
-      "properties": {
-        "vendor": {
-          "type": "string",
-          "description": "Required. At the moment, only `aws` is supported."
-        },
-        "filterId": {
-          "type": "string",
-          "description": "Required. Filter Id."
-        },
-        "filterName": {
-          "type": "string",
-          "title": "Required. Filter Name. Specify characters between 1 ~ 100"
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Required. If set, reads the usage-based cost details of this group. Only valid for Ripple users. Implied as the parent billing group for Wave(Pro) users.\n\nFor AWS Ripple, only billing internal ids are supported at the moment. Overriden when `accountId` is set to anything other than `*`. Set this and `accountId` to `*` to read the usage-based cost details of the whole organization. Optional for AWS Wave(Pro)."
-        },
-        "accountId": {
-          "type": "string",
-          "description": "Required. You can set it to a single account or a comma-separated list of accounts.\n\nFor AWS, setting this will override `groupId`. Set this and `groupId` to `*` to read the usage-based cost details of the whole organization."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1ReadCostsRequestAwsOptions",
-          "description": "Required. Valid only for the `aws` vendor. AWS-specific options."
-        }
-      },
-      "description": "Request message for the UpdateCostFilters rpc."
     },
     "v1UpdateCostFiltersResponse": {
       "type": "object",
@@ -24862,20 +24048,6 @@
       },
       "description": "Response message for the UpdateCostFilters rpc."
     },
-    "v1UpdateCostGroupColorThemeRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "colorTheme": {
-          "type": "string",
-          "description": "Required. Color Theme."
-        }
-      },
-      "title": "Request message for UpdateCostGroupColorTheme"
-    },
     "v1UpdateCostGroupColorThemeResponse": {
       "type": "object",
       "properties": {
@@ -24884,19 +24056,6 @@
         }
       },
       "title": "Response message for UpdateCostGroupColorTheme"
-    },
-    "v1UpdateCostGroupCombinationsRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "combinations": {
-          "$ref": "#/definitions/coverCombinations"
-        }
-      },
-      "title": "Request message for UpdateCostGroupCombinations"
     },
     "v1UpdateCostGroupCombinationsResponse": {
       "type": "object",
@@ -24907,20 +24066,6 @@
       },
       "title": "Response message for UpdateCostGroupCombinations"
     },
-    "v1UpdateCostGroupDescriptionRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "description": {
-          "type": "string",
-          "description": "Required. Description."
-        }
-      },
-      "title": "Request message for UpdateCostGroupDescription"
-    },
     "v1UpdateCostGroupDescriptionResponse": {
       "type": "object",
       "properties": {
@@ -24929,20 +24074,6 @@
         }
       },
       "title": "Response message for UpdateCostGroupDescription"
-    },
-    "v1UpdateCostGroupIconRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "icon": {
-          "type": "string",
-          "description": "Required. Icon."
-        }
-      },
-      "title": "Request message for UpdateCostGroupIcon"
     },
     "v1UpdateCostGroupIconResponse": {
       "type": "object",
@@ -24953,20 +24084,6 @@
       },
       "title": "Response message for UpdateCostGroupIcon"
     },
-    "v1UpdateCostGroupImageRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "image": {
-          "type": "string",
-          "description": "Required. Image."
-        }
-      },
-      "title": "Request message for UpdateCostGroupImage"
-    },
     "v1UpdateCostGroupImageResponse": {
       "type": "object",
       "properties": {
@@ -24976,20 +24093,6 @@
       },
       "title": "Response message for UpdateCostGroupImage"
     },
-    "v1UpdateCostGroupNameRequest": {
-      "type": "object",
-      "properties": {
-        "costGroupId": {
-          "type": "string",
-          "description": "Required. Cost Group Id."
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. Name."
-        }
-      },
-      "title": "Request message for UpdateCostGroupName"
-    },
     "v1UpdateCostGroupNameResponse": {
       "type": "object",
       "properties": {
@@ -24998,126 +24101,6 @@
         }
       },
       "title": "Response message for UpdateCostGroupName"
-    },
-    "v1UpdateDataAccessRequest": {
-      "type": "object",
-      "properties": {
-        "target": {
-          "type": "string",
-          "title": "Project Id for GCP, Account Id for Azure"
-        },
-        "vendor": {
-          "type": "string",
-          "title": "GCP or Azure"
-        },
-        "gcpOptions": {
-          "$ref": "#/definitions/coverGcpOptions",
-          "title": "GCP Options"
-        },
-        "azureOptions": {
-          "$ref": "#/definitions/coverAzureOptions",
-          "title": "Azure Options"
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/apicoverAwsOptions",
-          "title": "AWS Options"
-        },
-        "accountType": {
-          "type": "string",
-          "title": "Account Type"
-        }
-      },
-      "title": "Request message for UpdateDataAccess (GCP/Azure)"
-    },
-    "v1UpdateDiscountExpirationAlertRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "title": "required. Id"
-        },
-        "alertEnabled": {
-          "type": "boolean",
-          "description": "required."
-        },
-        "channels": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "required. Notification Channel Ids."
-        },
-        "frequencies": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "int64"
-          },
-          "description": "required. Frequencies."
-        },
-        "costGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "title": "Required. Cost Group Ids"
-        },
-        "name": {
-          "type": "string",
-          "title": "required. Name"
-        }
-      }
-    },
-    "v1UpdateFeatureFlagsRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "featureFlags": {
-          "$ref": "#/definitions/apiFeatureFlags"
-        }
-      },
-      "description": "Request message for the Iam.UpdateFeatureFlags rpc."
-    },
-    "v1UpdateInvoicePreviewsRequest": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string",
-          "description": "Required. Month to get invoice. Format: `yyyymm`."
-        },
-        "allGroups": {
-          "type": "boolean",
-          "description": "Optional. You can set all billing groups.\n\nIf this parameter is not set, The list set to `groups` is used."
-        },
-        "groups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "title": "Optional. You can set it to a list of billing internal group id"
-        },
-        "enabled": {
-          "type": "boolean",
-          "description": "Required. You can set display or hiding.\n\nIf true, Hiding Invoice. If false, Display Invoice."
-        }
-      },
-      "description": "Request message for the UpdateInvoicePreviews rpc."
-    },
-    "v1UpdateMemberPermissionRequest": {
-      "type": "object",
-      "properties": {
-        "userId": {
-          "type": "string",
-          "description": "Required. UserId."
-        },
-        "isAdmin": {
-          "type": "boolean",
-          "description": "Required. IsAdmin."
-        }
-      },
-      "title": "Request message for UpdateMemberPermission"
     },
     "v1UpdateMemberPermissionResponse": {
       "type": "object",
@@ -25140,69 +24123,6 @@
       },
       "description": "Request message for the Organization.UpdateMetadata rpc."
     },
-    "v1UpdateNotificationChannelRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. ID of the notification channel to update."
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. Name of the notification channel."
-        },
-        "type": {
-          "type": "string",
-          "description": "Required. Valid values: `email`, `slack`, `msteams`."
-        },
-        "email": {
-          "$ref": "#/definitions/apiEmailChannel",
-          "description": "Required if type = `email`."
-        },
-        "slack": {
-          "$ref": "#/definitions/apiSlackChannel",
-          "description": "Required if type = `slack`."
-        },
-        "msteams": {
-          "$ref": "#/definitions/apiMSTeamsChannel",
-          "description": "Required if type = `msteams`."
-        },
-        "product": {
-          "type": "string",
-          "description": "Optional. For Octo use only: `octo`."
-        }
-      },
-      "description": "Request message for the Admin.UpdateNotificationChannel rpc."
-    },
-    "v1UpdateNotificationRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "title": "Required"
-        },
-        "channels": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "title": "Required"
-        },
-        "enabled": {
-          "type": "boolean",
-          "title": "Required"
-        },
-        "notificationType": {
-          "type": "string",
-          "description": "Required\nValid values: \n`InvoiceCalculationStarted`, \n`InvoiceCalculationFinished`, \n`CurUpdatedAfterInvoice`.\n`AccountBudgetAlert`."
-        },
-        "account": {
-          "$ref": "#/definitions/adminv1NotificationAccount",
-          "description": "Optional. only available Wave(Pro)."
-        }
-      },
-      "description": "Request message for the Admin.UpdateNotificationTypeChannels rpc."
-    },
     "v1UpdatePasswordRequest": {
       "type": "object",
       "properties": {
@@ -25214,99 +24134,6 @@
         }
       },
       "description": "Request message for the Organization.UpdatePassword rpc."
-    },
-    "v1UpdateResellerRequest": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Required. reseller id.",
-          "required": [
-            "id"
-          ]
-        },
-        "email": {
-          "type": "string",
-          "description": "Optional."
-        },
-        "password": {
-          "type": "string",
-          "description": "Optional.\n\nWe recommend a password length of 8~32 characters. If you send 0 characters, a password will be generated automatically."
-        },
-        "waveConfig": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/rippleResellerConfig"
-          },
-          "description": "Set only the config to be changed.\nFor example, If you want to change only dashboardGraph, set `{\"waveConfig\": [{\"key\": \"dashboardGraph\",\"value\": true}]}` as a parameter",
-          "title": "Optional. wave feature config"
-        },
-        "aquaConfig": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/rippleResellerConfig"
-          },
-          "description": "Set only the config to be changed.\nFor example, If you want to change only aqRiManagement, set `{\"waveConfig\": [{\"key\": \"aqRiManagement\",\"value\": true}]}` as a parameter",
-          "title": "Optional. aqua feature config"
-        },
-        "notification": {
-          "type": "boolean",
-          "description": "Optional.\n\nIf valid when email or password is updated, you will be notified via email address.\nIf only waveConfig or aquaConfig is changed, it is ignored."
-        },
-        "updateMask": {
-          "type": "string",
-          "description": "Required.",
-          "required": [
-            "updateMask"
-          ]
-        }
-      },
-      "description": "Request message for the UpdateReseller rpc.",
-      "required": [
-        "id",
-        "updateMask"
-      ]
-    },
-    "v1UpdateRoleRequest": {
-      "type": "object",
-      "properties": {
-        "namespace": {
-          "type": "string",
-          "description": "Required. The new namespace."
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. The role name to update."
-        },
-        "newName": {
-          "type": "string",
-          "description": "Optional. If set, update the current name to this."
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. The list of permissions to attach to this role."
-        }
-      },
-      "description": "Request message for the Iam.UpdateRole rpc."
-    },
-    "v1UpdateSideMenuStateRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string",
-          "description": "Required. View Id."
-        },
-        "sidemenustate": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/coverSideMenuState"
-          }
-        }
-      },
-      "title": "Request message for UpdateSideMenuState"
     },
     "v1UpdateSideMenuStateResponse": {
       "type": "object",
@@ -25492,6 +24319,7 @@
         "roles": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/v1MapRole"
           },
           "description": "Required. The roles to map to the user. Limited to 5 items. Setting `role` to empty will remove the mapping."
@@ -25541,18 +24369,6 @@
       },
       "title": "Response message for UpdateUserTimezone"
     },
-    "v1UpdateViewColorThemeRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string"
-        },
-        "colorTheme": {
-          "type": "string"
-        }
-      },
-      "title": "Request message for UpdateViewColorTheme"
-    },
     "v1UpdateViewColorThemeResponse": {
       "type": "object",
       "properties": {
@@ -25562,61 +24378,18 @@
       },
       "title": "Response message for UpdateViewColorTheme"
     },
-    "v1UpdateViewLayoutRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string",
-          "description": "Required. View Id."
-        },
-        "layout": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/coverWidgetData"
-          }
-        }
-      },
-      "title": "Request message for UpdateViewLayout"
-    },
     "v1UpdateViewLayoutResponse": {
       "type": "object",
       "properties": {
         "layout": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/coverViewLayout"
           }
         }
       },
       "title": "Response message for UpdateViewLayout"
-    },
-    "v1UpdateViewRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string",
-          "description": "Required. View Id."
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "icon": {
-          "type": "string"
-        },
-        "isPrivate": {
-          "type": "boolean"
-        },
-        "isEditable": {
-          "type": "boolean"
-        },
-        "colorTheme": {
-          "type": "string"
-        }
-      },
-      "title": "Request message for UpdateView"
     },
     "v1UpdateViewResponse": {
       "type": "object",
@@ -25626,29 +24399,6 @@
         }
       },
       "title": "Response message for UpdateView"
-    },
-    "v1UpdateViewWidgetRequest": {
-      "type": "object",
-      "properties": {
-        "viewId": {
-          "type": "string",
-          "description": "Required. View Id."
-        },
-        "widgetId": {
-          "type": "string",
-          "description": "Required. Widget Id."
-        },
-        "options": {
-          "type": "object"
-        },
-        "requests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/coverLayoutRequests"
-          }
-        }
-      },
-      "title": "Request message for UpdateViewWidget"
     },
     "v1UpdateViewWidgetResponse": {
       "type": "object",
@@ -25667,15 +24417,18 @@
       "properties": {
         "name": {
           "type": "string",
+          "description": "file name",
           "title": "Required. File name"
         },
         "type": {
           "type": "string",
+          "description": "file type",
           "title": "Required. File type"
         },
         "file": {
           "type": "string",
           "format": "byte",
+          "description": "file in bytes",
           "title": "Required. Convert file into bytes to transfer file"
         }
       },


### PR DESCRIPTION
modify gcp account access related fields, old ones still expect account type: prjoject, current one only needs account type: billing 