### PR TITLE
refactor: rename GetCalculationPrerequisites to ListCalculationPrerequisites and update related messages

### DIFF
--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -594,8 +594,8 @@ service Cost {
     };
   }
 
-  // WORK-IN-PROGRESS: Get invoice id for a month
-  rpc GetCalculationPrerequisites (GetCalculationPrerequisitesRequest) returns (GetCalculationPrerequisitesResponse) {
+  // WORK-IN-PROGRESS: List the prerequisites for cost calculations.
+  rpc ListCalculationPrerequisites (ListCalculationPrerequisitesRequest) returns (ListCalculationPrerequisitesResponse) {
     option (google.api.http) = {
       get: "/v1/{vendor}/calculation/prerequisites/{month}"
     };
@@ -2288,8 +2288,8 @@ message RegisterPayerAccountRequest {
   string curType = 4;
 }
 
- // WORK-IN-PROGRESS: Get CUR invoice id list
-message GetCalculationPrerequisitesRequest {
+// WORK-IN-PROGRESS: List the prerequisites for cost calculations.
+message ListCalculationPrerequisitesRequest {
   // Required. At the moment, only `aws` is supported.
   string vendor = 1;
   
@@ -2297,16 +2297,21 @@ message GetCalculationPrerequisitesRequest {
   string month = 2;
 }
 
-message GetCalculationPrerequisitesResponse {
-    // The invoice id.
-    string invoice_id = 1;
-    
-    // The payer account id.
-    string payer_id = 2;
-    
-    // The exchange rate.
-    double exchange_rate = 3;
-    
-    // The unblended cost in CUR.
-    double unblended_cost_in_cur = 4;
+message CalculationPrerequisite {
+  // The invoice id.
+  string invoice_id = 1;
+  
+  // The payer account id.
+  string payer_id = 2;
+  
+  // The exchange rate.
+  double exchange_rate = 3;
+  
+  // The unblended cost in CUR.
+  double unblended_cost_in_cur = 4;
+}
+
+message ListCalculationPrerequisitesResponse {
+  // Repeated list of calculation prerequisites.
+  repeated CalculationPrerequisite prerequisites = 1;
 }

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -13683,13 +13683,13 @@
     },
     "/v1/{vendor}/calculation/prerequisites/{month}": {
       "get": {
-        "summary": "WORK-IN-PROGRESS: Get invoice id for a month",
-        "operationId": "Cost_GetCalculationPrerequisites",
+        "summary": "WORK-IN-PROGRESS: List the prerequisites for cost calculations.",
+        "operationId": "Cost_ListCalculationPrerequisites",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1GetCalculationPrerequisitesResponse"
+              "$ref": "#/definitions/v1ListCalculationPrerequisitesResponse"
             }
           },
           "default": {
@@ -30506,26 +30506,34 @@
         }
       }
     },
-    "v1GetCalculationPrerequisitesResponse": {
+    "v1ListCalculationPrerequisitesResponse": {
       "type": "object",
       "properties": {
-        "invoiceId": {
-          "type": "string",
-          "description": "The invoice id."
-        },
-        "payerId": {
-          "type": "string",
-          "description": "The payer account id."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate."
-        },
-        "unblendedCostInCur": {
-          "type": "number",
-          "format": "double",
-          "description": "The unblended cost in CUR."
+        "prerequisites": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "invoiceId": {
+                "type": "string",
+                "description": "The invoice id."
+              },
+              "payerId": {
+                "type": "string",
+                "description": "The payer account id."
+              },
+              "exchangeRate": {
+                "type": "number",
+                "format": "double",
+                "description": "The exchange rate."
+              },
+              "unblendedCostInCur": {
+                "type": "number",
+                "format": "double",
+                "description": "The unblended cost in CUR."
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## What's New

### Changes in Cost API

#### Renamed `GetCalculationPrerequisites` to `ListCalculationPrerequisites`
- **Renamed RPC method:**
  - `GetCalculationPrerequisites` → `ListCalculationPrerequisites`
- **Updated request and response messages:**
  - `GetCalculationPrerequisitesRequest` → `ListCalculationPrerequisitesRequest`
  - `GetCalculationPrerequisitesResponse` → `ListCalculationPrerequisitesResponse`
- **Modified response structure:**
  - Introduced a `CalculationPrerequisite` message
  - `ListCalculationPrerequisitesResponse` now contains a repeated list of `CalculationPrerequisite` objects instead of individual fields

#### API Endpoint Changes

- The HTTP endpoint remains unchanged:
  - **GET** `/v1/{vendor}/calculation/prerequisites/{month}`
- Updated documentation to reflect these changes

