### PR TITLE
Flow API: Add GetDashboardData RPC to retrieve per-day dashboard data

### DIFF
--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -435,6 +435,9 @@ message DashboardData {
 
   // Raw tags or metadata associated with the applied Savings Plan.
   string spTags = 14;
+
+  // The user or system that purchased the Savings Plan.
+  string purchasedBy = 15;
 }
 
 // Response message for the Flow.GetDashboardData rpc.

--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -1,447 +1,447 @@
-syntax = "proto3";
+  syntax = "proto3";
 
-package blueapi.flow.v1;
+  package blueapi.flow.v1;
 
-import "google/api/annotations.proto";
-import "protoc-gen-openapiv2/options/annotations.proto";
+  import "google/api/annotations.proto";
+  import "protoc-gen-openapiv2/options/annotations.proto";
 
-option go_package = "github.com/alphauslabs/blueapi/flow";
-option java_package = "cloud.alphaus.api.flow";
-option java_outer_classname = "FlowProto";
+  option go_package = "github.com/alphauslabs/blueapi/flow";
+  option java_package = "cloud.alphaus.api.flow";
+  option java_outer_classname = "FlowProto";
 
-// Flow service definition.
-service Flow {
-  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {
-    description: "(ALPHA) Flow API. Base URL: https://api.alphaus.cloud/m/blue/flow"
-    external_docs: {
-      url: "https://github.com/alphauslabs/blueapi/tree/main/flow/";
-      description: "Service definition";
+  // Flow service definition.
+  service Flow {
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {
+      description: "(ALPHA) Flow API. Base URL: https://api.alphaus.cloud/m/blue/flow"
+      external_docs: {
+        url: "https://github.com/alphauslabs/blueapi/tree/main/flow/";
+        description: "Service definition";
+      }
+    };
+    
+    // For Testing Purposes Only.
+    rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {
+      option (google.api.http) = {
+        get: "/v1/info"
+      };
     }
-  };
-  
-  // For Testing Purposes Only.
-  rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {
-    option (google.api.http) = {
-      get: "/v1/info"
-    };
+
+    // Creates a new settings configuration for the user.
+    rpc CreateSettings(CreateSettingsRequest) returns (CreateSettingsResponse) {
+      option (google.api.http) = {
+        post: "/v1/settings"
+        body: "*";
+      };
+    }
+
+    // Update the settings configuration for a user.
+    rpc UpdateSettings(UpdateSettingsRequest) returns (UpdateSettingsResponse) {
+      option (google.api.http) = {
+        put: "/v1/settings/{id}"
+        body: "*";
+      };
+    }
+
+    // Fetch previous settings for a user
+    rpc GetSettings(GetSettingsRequest) returns (GetSettingsResponse) {
+      option (google.api.http) = {
+        get: "/v1/settings/{id}"
+      };
+    }
+
+    // Fetch user savings plan details
+    rpc GetRecommendationDetails(GetRecommendationDetailsRequest) returns (GetRecommendationDetailsResponse) {
+      option (google.api.http) = {
+        get: "/v1/settings/recommendations/{id}"
+      };
+    }
+
+    // Gets a CloudFormation launch URL for enabling read-only cross-account access to cost explorer information (API only).
+    rpc GetCostExplorerAccessTemplateUrl(GetCostExplorerAccessTemplateUrlRequest) returns (GetCostExplorerAccessTemplateUrlResponse) {
+      option (google.api.http) = {
+        get: "/v1/aws/xacct/cea"
+      };
+    }
+
+    // Gets the settings configuration history for a user.
+    rpc GetSettingsHistory(GetSettingsHistoryRequest) returns (GetSettingsHistoryResponse) {
+      option (google.api.http) = {
+        get: "/v1/settings/history/{id}"
+      };
+    }
+
+    // Creates a default cross-account access role for cost explorer (API only).
+    rpc CreateCostExplorerAccess(CreateCostExplorerAccessRequest) returns (CreateCostExplorerAccessResponse) {
+      option (google.api.http) = {
+        post: "/v1/aws/xacct/cea"
+        body: "*"
+      };
+    }
+
+    // Gets the data for the Flow Dashboard.
+    rpc GetPurchasedRecommendationDetails (GetPurchasedRecommendationDetailsRequest) returns (GetPurchasedRecommendationDetailsResponse) {
+      option (google.api.http) = {
+        post: "/v1/recommendations/purchased"
+        body: "*"
+      };
+    }
   }
 
-  // Creates a new settings configuration for the user.
-  rpc CreateSettings(CreateSettingsRequest) returns (CreateSettingsResponse) {
-    option (google.api.http) = {
-      post: "/v1/settings"
-      body: "*";
-    };
+  // ##################################### REQUESTS #####################################
+
+  // Request message for the Flow.GetInfo rpc.
+  message GetInfoRequest {}
+
+  // Request message for the Flow.CreateSettings rpc.
+  message CreateSettingsRequest {
+    // Required. The id of the payer.
+    string id = 1;
+
+    // Required. Account scope determines if the account is payer or linked account. Valid values are `payer` or `linked`.
+    string accountScope = 2;
+
+    // Required. Customization setting for SP. Valid values are `COMPUTE_SP` or `EC2_INSTANCE_SP`.
+    string customization = 3;
+
+    // Required. Term of the SP. Valid values are `ONE_YEAR` or `THREE_YEARS`.
+    string planTerm = 4;
+
+    // Required. Payment option for the SP. Valid values are `ALL_UPFRONT`, `PARTIAL_UPFRONT`, or `NO_UPFRONT`.
+    string paymentOption = 5;
+
+    // Required. Lookback period for recommendation. Valid values are `SEVEN_DAYS`, `THIRTY_DAYS`, or `SIXTY_DAYS`.
+    string lookBackPeriod = 6;
+
+    // Optional. If EC2 Instance SP is selected in Customization, request will include list of instance family
+    string instanceFamily = 7;
+
+    // Optional. Annual budget input for SP.
+    double annualBudget = 8;
+
+    // Optional. Purchase approval from the payer for the SP. Default value is `false`.
+    bool approval = 9;
+
+    // Required. Payer account ID
+    string payerId = 10;
   }
 
-  // Update the settings configuration for a user.
-  rpc UpdateSettings(UpdateSettingsRequest) returns (UpdateSettingsResponse) {
-    option (google.api.http) = {
-      put: "/v1/settings/{id}"
-      body: "*";
-    };
+  // Request message for the Flow.UpdateSettings rpc.
+  message UpdateSettingsRequest {
+    // Required. The id of the payer to update.
+    string id = 1;
+
+    // Optional. Update account scope (payer or linked).
+    optional string accountScope = 2;
+
+    // Optional. Update customization setting.
+    optional string customization = 3;
+
+    // Optional. Update term of the SP.
+    optional string planTerm = 4;
+
+    // Optional. Update payment option.
+    optional string paymentOption = 5;
+
+    // Optional. Update lookback period.
+    optional string lookBackPeriod = 6;
+
+    // Optional. Update list of instance families.
+    optional string instanceFamily = 7;
+
+    // Optional. Update annual budget.
+    optional double annualBudget = 8;
+
+    // Optional. Update purchase approval.
+    optional bool approval = 9;
+
+    // Optional. Update used payerId.
+    optional string payerId = 10;
   }
 
-  // Fetch previous settings for a user
-  rpc GetSettings(GetSettingsRequest) returns (GetSettingsResponse) {
-    option (google.api.http) = {
-      get: "/v1/settings/{id}"
-    };
+  // Request message for fetching previous settings configuration of a user.
+  message GetSettingsRequest {
+    // Required. The id of the payer to fetch settings for.
+    string id = 1;
   }
 
-  // Fetch user savings plan details
-  rpc GetRecommendationDetails(GetRecommendationDetailsRequest) returns (GetRecommendationDetailsResponse) {
-    option (google.api.http) = {
-      get: "/v1/settings/recommendations/{id}"
-    };
+  message GetRecommendationDetailsRequest {
+    // Required. The id of the payer to fetch recommendation details for.
+    string id = 1;
   }
 
-  // Gets a CloudFormation launch URL for enabling read-only cross-account access to cost explorer information (API only).
-  rpc GetCostExplorerAccessTemplateUrl(GetCostExplorerAccessTemplateUrlRequest) returns (GetCostExplorerAccessTemplateUrlResponse) {
-    option (google.api.http) = {
-      get: "/v1/aws/xacct/cea"
-    };
+  // Request message for the Flow.GetCostExplorerAccessTemplateUrl rpc.
+  // This endpoint only supports the 'apionly' template type.
+  message GetCostExplorerAccessTemplateUrlRequest {}
+
+  // Request message for the Flow.GetSettingsHistory rpc.
+  message GetSettingsHistoryRequest {
+    // Required. The id of the payer to fetch settings history for.
+    string id = 1;
   }
 
-  // Gets the settings configuration history for a user.
-  rpc GetSettingsHistory(GetSettingsHistoryRequest) returns (GetSettingsHistoryResponse) {
-    option (google.api.http) = {
-      get: "/v1/settings/history/{id}"
-    };
+  // Request message for the Flow.CreateCostExplorerAccess rpc.
+  // This endpoint only supports the 'apionly' template type.
+  message CreateCostExplorerAccessRequest {
+    // Required. The target AWS account to validate.
+    string target = 1;
   }
 
-  // Creates a default cross-account access role for cost explorer (API only).
-  rpc CreateCostExplorerAccess(CreateCostExplorerAccessRequest) returns (CreateCostExplorerAccessResponse) {
-    option (google.api.http) = {
-      post: "/v1/aws/xacct/cea"
-      body: "*"
-    };
+  // Request message for the Flow.GetPurchasedRecommendationDetails rpc.
+  message GetPurchasedRecommendationDetailsRequest {
+    // The payer account ID to retrieve dashboard data for.
+    string payerId = 1;
+
+    // The start date of the dashboard range in YYYY-MM-DD format.
+    string startDate = 2;
+
+    // The end date of the dashboard range in YYYY-MM-DD format.
+    string endDate = 3;
   }
 
-  // Gets the data for the Flow Dashboard.
-  rpc GetDashboardData(GetDashboardDataRequest) returns (GetDashboardDataResponse) {
-    option (google.api.http) = {
-      post: "/v1/dashboard"
-      body: "*"
-    };
+  // ##################################### RESPONSES #####################################
+
+  // Response message for the Flow.GetInfo rpc.
+  message GetInfoResponse {
+    string response = 1;
   }
-}
 
-// ##################################### REQUESTS #####################################
+  // Response message for the Flow.CreateSettings rpc.
+  message CreateSettingsResponse {
+    string response = 1;
+  }
+
+  message UpdateSettingsResponse {
+    string response = 1;
+  }
+
+  // Response message for fetching previous settings configuration of a user.
+  message GetSettingsResponse {
+    // Unique ID of the settings entry
+    string id = 1;
+
+    // Account scope for the settings (payer or linked)
+    string accountScope = 2;
+
+    // Customization setting for the Savings Plan
+    string customization = 3;
+
+    // Savings Plan term (e.g., ONE_YEAR, THREE_YEARS)
+    string planTerm = 4;
+
+    // Payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT)
+    string paymentOption = 5;
+
+    // Lookback period used for the Savings Plan recommendation (e.g., SEVEN_DAYS, THIRTY_DAYS, SIXTY_DAYS)
+    string lookBackPeriod = 6;
+
+    // Instance family for the Savings Plan, if applicable
+    string instanceFamily = 7;
+
+    // Annual budget set for the Savings Plan
+    double annualBudget = 8;
+
+    // Indicates whether the settings were approved by the payer
+    bool approval = 9;
+
+    // The last updated timestamp for this settings entry, in RFC3339 UTC format
+    string lastUpdated = 10;
+
+    // Payer account ID associated with the settings
+    string payerId = 11;
+  }
+
+  message GetRecommendationDetailsResponse {
+    // Unique ID of the recommendation details entry
+    string id = 1;
+    
+    // Projected monthly on-demand spend without Savings Plans, normalized from lookback period
+    double currentMonthlyOnDemandSpend = 2;
+    
+    // Projected total monthly spend after applying the recommended Savings Plan, normalized
+    double estimatedMonthlySpend = 3;
+    
+    // Difference between on-demand and post-SP spend, computed from normalized values
+    double estimatedMonthlySavingsDerived = 4;
+    
+    // Total current daily cost from usage, before applying any SP recommendation (Derived)
+    double totalDailyCost = 5;
+    
+    // Current Savings Plan commitment applied 
+    double currentSPCommitment = 6;
+    
+    // Estimated daily on-demand cost without any Savings Plans
+    double estimatedOnDemandCost = 7;
+    
+    // Suggested hourly commitment to purchase in USD
+    double hourlyCommitment = 8;
+    
+    // Projected monthly savings from the recommended savings plan
+    double estimatedMonthlySavings = 9;
+    
+    // Percentage of potential savings from savings plan
+    double estimatedSavings = 10;
+    
+    // Customization setting for savings plan
+    string recommendationLevel = 11;
+    
+    // Savings plan type.
+    string planType = 12;
+    
+    // Savings plan duration.
+    string planTerm = 13;
+    
+    // Savings plan payment option.
+    string paymentOption = 14;
+    
+    // Savings plan lookback period used for analysis.
+    string lookBackPeriod = 15;
+    
+    // Savings plan estimated return on investment.
+    double estimatedROI = 16;
+    
+    // Savings plan total projected cost over the term.
+    double estimatedSPCost = 17;
+    
+    // Savings plan estimated total cost and including on-demand.
+    double estimatedTotalCost = 18;
+    
+    // Savings plan last updated
+    string lastUpdated = 19;
+  }
 
-// Request message for the Flow.GetInfo rpc.
-message GetInfoRequest {}
+  // Response message for the Flow.GetCostExplorerAccessTemplateUrl rpc.
+  message GetCostExplorerAccessTemplateUrlResponse {
+    // The CloudFormation launch url. Open it in your browser.
+    string launchUrl = 1;
 
-// Request message for the Flow.CreateSettings rpc.
-message CreateSettingsRequest {
-  // Required. The id of the payer.
-  string id = 1;
+    // The latest CloudFormation template. The version is included in the filename.
+    string templateUrl = 2;
 
-  // Required. Account scope determines if the account is payer or linked account. Valid values are `payer` or `linked`.
-  string accountScope = 2;
+    // The default stack name used. Can be modified.
+    string stackName = 3;
 
-  // Required. Customization setting for SP. Valid values are `COMPUTE_SP` or `EC2_INSTANCE_SP`.
-  string customization = 3;
+    // The AWS account that will receive the access. Do not change.
+    string principal = 4;
 
-  // Required. Term of the SP. Valid values are `ONE_YEAR` or `THREE_YEARS`.
-  string planTerm = 4;
+    // The external id for this role. Do not change.
+    string externalId = 5;
+  }
 
-  // Required. Payment option for the SP. Valid values are `ALL_UPFRONT`, `PARTIAL_UPFRONT`, or `NO_UPFRONT`.
-  string paymentOption = 5;
+  // Settings history message.
+  message SettingsHistory {
+    // Unique identifier for the settings history entry.
+    string id = 1;
 
-  // Required. Lookback period for recommendation. Valid values are `SEVEN_DAYS`, `THIRTY_DAYS`, or `SIXTY_DAYS`.
-  string lookBackPeriod = 6;
+    // The account scope for the settings (payer or linked).
+    string accountScope = 2;
 
-  // Optional. If EC2 Instance SP is selected in Customization, request will include list of instance family
-  string instanceFamily = 7;
+    // The customization setting for the Savings Plan.
+    string customization = 3;
 
-  // Optional. Annual budget input for SP.
-  double annualBudget = 8;
+    // The term of the Savings Plan (e.g., ONE_YEAR, THREE_YEARS).
+    string planTerm = 4;
 
-  // Optional. Purchase approval from the payer for the SP. Default value is `false`.
-  bool approval = 9;
+    // The payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT).
+    string paymentOption = 5;
 
-  // Required. Payer account ID
-  string payerId = 10;
-}
+    // The lookback period used for the Savings Plan recommendation.
+    string lookBackPeriod = 6;
 
-// Request message for the Flow.UpdateSettings rpc.
-message UpdateSettingsRequest {
-  // Required. The id of the payer to update.
-  string id = 1;
+    // The instance family for the Savings Plan, if applicable.
+    string instanceFamily = 7;
 
-  // Optional. Update account scope (payer or linked).
-  optional string accountScope = 2;
+    // The annual budget set for the Savings Plan.
+    double annualBudget = 8;
 
-  // Optional. Update customization setting.
-  optional string customization = 3;
+    // Indicates whether the settings were approved by the payer.
+    bool approval = 9;
 
-  // Optional. Update term of the SP.
-  optional string planTerm = 4;
+    // The last updated timestamp for this settings history entry, in RFC3339 UTC format.
+    string lastUpdated = 10;
+  }
 
-  // Optional. Update payment option.
-  optional string paymentOption = 5;
+  // Response message for the Flow.GetSettingsHistory rpc.
+  message GetSettingsHistoryResponse {
+    repeated SettingsHistory settingsHistory = 1;
+  }
 
-  // Optional. Update lookback period.
-  optional string lookBackPeriod = 6;
+  // Response message for the Flow.CreateCostExplorerAccess rpc.
+  message CreateCostExplorerAccessResponse {
+    // The queried target account.
+    string target = 1;
 
-  // Optional. Update list of instance families.
-  optional string instanceFamily = 7;
+    // The role ARN that provides the cross-account access permissions.
+    string roleArn = 2;
 
-  // Optional. Update annual budget.
-  optional double annualBudget = 8;
+    // The external id for this role.
+    string externalId = 3;
 
-  // Optional. Update purchase approval.
-  optional bool approval = 9;
+    // The id of the CloudFormation stack deployed in the target account.
+    string stackId = 4;
 
-  // Optional. Update used payerId.
-  optional string payerId = 10;
-}
+    // The region where the stack is deployed.
+    string stackRegion = 5;
 
-// Request message for fetching previous settings configuration of a user.
-message GetSettingsRequest {
-  // Required. The id of the payer to fetch settings for.
-  string id = 1;
-}
+    // The latest template used to deploy the stack.
+    string templateUrl = 6;
 
-message GetRecommendationDetailsRequest {
-  // Required. The id of the payer to fetch recommendation details for.
-  string id = 1;
-}
+    // This can be `latest`, `outdated`, or some error information.
+    string status = 7;
 
-// Request message for the Flow.GetCostExplorerAccessTemplateUrl rpc.
-// This endpoint only supports the 'apionly' template type.
-message GetCostExplorerAccessTemplateUrlRequest {}
-
-// Request message for the Flow.GetSettingsHistory rpc.
-message GetSettingsHistoryRequest {
-  // Required. The id of the payer to fetch settings history for.
-  string id = 1;
-}
-
-// Request message for the Flow.CreateCostExplorerAccess rpc.
-// This endpoint only supports the 'apionly' template type.
-message CreateCostExplorerAccessRequest {
-  // Required. The target AWS account to validate.
-  string target = 1;
-}
-
-// Request message for the Flow.GetDashboardData rpc.
-message GetDashboardDataRequest {
-  // The payer account ID to retrieve dashboard data for.
-  string payerId = 1;
-
-  // The start date of the dashboard range in YYYY-MM-DD format.
-  string startDate = 2;
-
-  // The end date of the dashboard range in YYYY-MM-DD format.
-  string endDate = 3;
-}
-
-// ##################################### RESPONSES #####################################
-
-// Response message for the Flow.GetInfo rpc.
-message GetInfoResponse {
-  string response = 1;
-}
-
-// Response message for the Flow.CreateSettings rpc.
-message CreateSettingsResponse {
-  string response = 1;
-}
-
-message UpdateSettingsResponse {
-  string response = 1;
-}
-
-// Response message for fetching previous settings configuration of a user.
-message GetSettingsResponse {
-  // Unique ID of the settings entry
-  string id = 1;
-
-  // Account scope for the settings (payer or linked)
-  string accountScope = 2;
-
-  // Customization setting for the Savings Plan
-  string customization = 3;
-
-  // Savings Plan term (e.g., ONE_YEAR, THREE_YEARS)
-  string planTerm = 4;
-
-  // Payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT)
-  string paymentOption = 5;
-
-  // Lookback period used for the Savings Plan recommendation (e.g., SEVEN_DAYS, THIRTY_DAYS, SIXTY_DAYS)
-  string lookBackPeriod = 6;
-
-  // Instance family for the Savings Plan, if applicable
-  string instanceFamily = 7;
-
-  // Annual budget set for the Savings Plan
-  double annualBudget = 8;
-
-  // Indicates whether the settings were approved by the payer
-  bool approval = 9;
-
-  // The last updated timestamp for this settings entry, in RFC3339 UTC format
-  string lastUpdated = 10;
-
-  // Payer account ID associated with the settings
-  string payerId = 11;
-}
-
-message GetRecommendationDetailsResponse {
-  // Unique ID of the recommendation details entry
-  string id = 1;
-  
-  // Projected monthly on-demand spend without Savings Plans, normalized from lookback period
-  double currentMonthlyOnDemandSpend = 2;
-  
-  // Projected total monthly spend after applying the recommended Savings Plan, normalized
-  double estimatedMonthlySpend = 3;
-  
-  // Difference between on-demand and post-SP spend, computed from normalized values
-  double estimatedMonthlySavingsDerived = 4;
-  
-  // Total current daily cost from usage, before applying any SP recommendation (Derived)
-  double totalDailyCost = 5;
-  
-  // Current Savings Plan commitment applied 
-  double currentSPCommitment = 6;
-  
-  // Estimated daily on-demand cost without any Savings Plans
-  double estimatedOnDemandCost = 7;
-  
-  // Suggested hourly commitment to purchase in USD
-  double hourlyCommitment = 8;
-  
-  // Projected monthly savings from the recommended savings plan
-  double estimatedMonthlySavings = 9;
-  
-  // Percentage of potential savings from savings plan
-  double estimatedSavings = 10;
-  
-  // Customization setting for savings plan
-  string recommendationLevel = 11;
-  
-  // Savings plan type.
-  string planType = 12;
-  
-  // Savings plan duration.
-  string planTerm = 13;
-  
-  // Savings plan payment option.
-  string paymentOption = 14;
-  
-  // Savings plan lookback period used for analysis.
-  string lookBackPeriod = 15;
-  
-  // Savings plan estimated return on investment.
-  double estimatedROI = 16;
-  
-  // Savings plan total projected cost over the term.
-  double estimatedSPCost = 17;
-  
-  // Savings plan estimated total cost and including on-demand.
-  double estimatedTotalCost = 18;
-  
-  // Savings plan last updated
-  string lastUpdated = 19;
-}
-
-// Response message for the Flow.GetCostExplorerAccessTemplateUrl rpc.
-message GetCostExplorerAccessTemplateUrlResponse {
-  // The CloudFormation launch url. Open it in your browser.
-  string launchUrl = 1;
-
-  // The latest CloudFormation template. The version is included in the filename.
-  string templateUrl = 2;
-
-  // The default stack name used. Can be modified.
-  string stackName = 3;
-
-  // The AWS account that will receive the access. Do not change.
-  string principal = 4;
-
-  // The external id for this role. Do not change.
-  string externalId = 5;
-}
-
-// Settings history message.
-message SettingsHistory {
-  // Unique identifier for the settings history entry.
-  string id = 1;
-
-  // The account scope for the settings (payer or linked).
-  string accountScope = 2;
-
-  // The customization setting for the Savings Plan.
-  string customization = 3;
-
-  // The term of the Savings Plan (e.g., ONE_YEAR, THREE_YEARS).
-  string planTerm = 4;
-
-  // The payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT).
-  string paymentOption = 5;
-
-  // The lookback period used for the Savings Plan recommendation.
-  string lookBackPeriod = 6;
-
-  // The instance family for the Savings Plan, if applicable.
-  string instanceFamily = 7;
-
-  // The annual budget set for the Savings Plan.
-  double annualBudget = 8;
-
-  // Indicates whether the settings were approved by the payer.
-  bool approval = 9;
-
-  // The last updated timestamp for this settings history entry, in RFC3339 UTC format.
-  string lastUpdated = 10;
-}
-
-// Response message for the Flow.GetSettingsHistory rpc.
-message GetSettingsHistoryResponse {
-  repeated SettingsHistory settingsHistory = 1;
-}
-
-// Response message for the Flow.CreateCostExplorerAccess rpc.
-message CreateCostExplorerAccessResponse {
-  // The queried target account.
-  string target = 1;
-
-  // The role ARN that provides the cross-account access permissions.
-  string roleArn = 2;
-
-  // The external id for this role.
-  string externalId = 3;
-
-  // The id of the CloudFormation stack deployed in the target account.
-  string stackId = 4;
-
-  // The region where the stack is deployed.
-  string stackRegion = 5;
-
-  // The latest template used to deploy the stack.
-  string templateUrl = 6;
-
-  // This can be `latest`, `outdated`, or some error information.
-  string status = 7;
-
-  // The last updated timestamp, RFC3339 UTC.
-  string lastUpdated = 8;
-}
-
-// Dashboard data message.
-message DashboardData {
-  // The payer account ID associated with the data.
-  string payerId = 1;
-
-  // The specific date this record summarizes (YYYY-MM-DD).
-  string currentDate = 2;
-
-  // Recommended hourly commitment for Savings Plan in USD.
-  double spRecommendation = 3;
-
-  // Estimated monthly savings from using Savings Plans in USD.
-  double estimatedSavings = 4;
-
-  // Estimated percentage savings compared to On-Demand costs.
-  double estimatedSavingsPercentage = 5;
-
-  // Total On-Demand usage in hours for the date.
-  double ondemandUsage = 6;
-
-  // Total On-Demand cost in USD for the date.
-  double ondemandCost = 7;
-  
-  // Total Reserved Instance usage in hours for the date.
-  double reservedUsage = 8;
-
-  // Total Reserved Instance cost in USD for the date.
-  double reservedCost = 9;
-
-  // Total Savings Plan usage in hours for the date.
-  double savingsPlanUsage = 10;
-
-  // Total Savings Plan cost in USD for the date.
-  double savingsPlanCost = 11;
-
-  // Total Spot Instance usage in hours for the date.
-  double spotUsage = 12;
-
-  // Total Spot Instance cost in USD for the date.
-  double spotCost = 13;
-
-  // Raw tags or metadata associated with the applied Savings Plan.
-  string spTags = 14;
-
-  // The user or system that purchased the Savings Plan.
-  string purchasedBy = 15;
-}
-
-// Response message for the Flow.GetDashboardData rpc.
-message GetDashboardDataResponse {
-  // List of daily dashboard data entries within the requested date range.
-  repeated DashboardData dashboardData = 1;
-}
+    // The last updated timestamp, RFC3339 UTC.
+    string lastUpdated = 8;
+  }
+
+  // Dashboard data message.
+  message PurchasedRecommendationDetails {
+    // The payer account ID associated with the data.
+    string payerId = 1;
+
+    // The specific date this record summarizes (YYYY-MM-DD).
+    string currentDate = 2;
+
+    // Recommended hourly commitment for Savings Plan in USD.
+    double spRecommendation = 3;
+
+    // Estimated monthly savings from using Savings Plans in USD.
+    double estimatedSavings = 4;
+
+    // Estimated percentage savings compared to On-Demand costs.
+    double estimatedSavingsPercentage = 5;
+
+    // Total On-Demand usage in hours for the date.
+    double ondemandUsage = 6;
+
+    // Total On-Demand cost in USD for the date.
+    double ondemandCost = 7;
+    
+    // Total Reserved Instance usage in hours for the date.
+    double reservedUsage = 8;
+
+    // Total Reserved Instance cost in USD for the date.
+    double reservedCost = 9;
+
+    // Total Savings Plan usage in hours for the date.
+    double savingsPlanUsage = 10;
+
+    // Total Savings Plan cost in USD for the date.
+    double savingsPlanCost = 11;
+
+    // Total Spot Instance usage in hours for the date.
+    double spotUsage = 12;
+
+    // Total Spot Instance cost in USD for the date.
+    double spotCost = 13;
+
+    // Raw tags or metadata associated with the applied Savings Plan.
+    string spTags = 14;
+
+    // The user or system that purchased the Savings Plan.
+    string purchasedBy = 15;
+  }
+
+  // Response message for the Flow.GetDashboardData rpc.
+  message GetPurchasedRecommendationDetailsResponse {
+    // List of daily dashboard data entries within the requested date range.
+    repeated PurchasedRecommendationDetails purchasedRecommendationDetails = 1;
+  }

--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -77,6 +77,14 @@ service Flow {
       body: "*"
     };
   }
+
+  // Gets the data for the Flow Dashboard.
+  rpc GetDashboardData(GetDashboardDataRequest) returns (GetDashboardDataResponse) {
+    option (google.api.http) = {
+      post: "/v1/dashboard"
+      body: "*"
+    };
+  }
 }
 
 // ##################################### REQUESTS #####################################
@@ -178,6 +186,18 @@ message CreateCostExplorerAccessRequest {
   string target = 1;
 }
 
+// Request message for the Flow.GetDashboardData rpc.
+message GetDashboardDataRequest {
+  // The payer account ID to retrieve dashboard data for.
+  string payerId = 1;
+
+  // The start date of the dashboard range in YYYY-MM-DD format.
+  string startDate = 2;
+
+  // The end date of the dashboard range in YYYY-MM-DD format.
+  string endDate = 3;
+}
+
 // ##################################### RESPONSES #####################################
 
 // Response message for the Flow.GetInfo rpc.
@@ -196,16 +216,37 @@ message UpdateSettingsResponse {
 
 // Response message for fetching previous settings configuration of a user.
 message GetSettingsResponse {
+  // Unique ID of the settings entry
   string id = 1;
+
+  // Account scope for the settings (payer or linked)
   string accountScope = 2;
+
+  // Customization setting for the Savings Plan
   string customization = 3;
+
+  // Savings Plan term (e.g., ONE_YEAR, THREE_YEARS)
   string planTerm = 4;
+
+  // Payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT)
   string paymentOption = 5;
+
+  // Lookback period used for the Savings Plan recommendation (e.g., SEVEN_DAYS, THIRTY_DAYS, SIXTY_DAYS)
   string lookBackPeriod = 6;
+
+  // Instance family for the Savings Plan, if applicable
   string instanceFamily = 7;
+
+  // Annual budget set for the Savings Plan
   double annualBudget = 8;
+
+  // Indicates whether the settings were approved by the payer
   bool approval = 9;
+
+  // The last updated timestamp for this settings entry, in RFC3339 UTC format
   string lastUpdated = 10;
+
+  // Payer account ID associated with the settings
   string payerId = 11;
 }
 
@@ -288,15 +329,34 @@ message GetCostExplorerAccessTemplateUrlResponse {
 
 // Settings history message.
 message SettingsHistory {
+  // Unique identifier for the settings history entry.
   string id = 1;
+
+  // The account scope for the settings (payer or linked).
   string accountScope = 2;
+
+  // The customization setting for the Savings Plan.
   string customization = 3;
+
+  // The term of the Savings Plan (e.g., ONE_YEAR, THREE_YEARS).
   string planTerm = 4;
+
+  // The payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT).
   string paymentOption = 5;
+
+  // The lookback period used for the Savings Plan recommendation.
   string lookBackPeriod = 6;
+
+  // The instance family for the Savings Plan, if applicable.
   string instanceFamily = 7;
+
+  // The annual budget set for the Savings Plan.
   double annualBudget = 8;
+
+  // Indicates whether the settings were approved by the payer.
   bool approval = 9;
+
+  // The last updated timestamp for this settings history entry, in RFC3339 UTC format.
   string lastUpdated = 10;
 }
 
@@ -330,4 +390,55 @@ message CreateCostExplorerAccessResponse {
 
   // The last updated timestamp, RFC3339 UTC.
   string lastUpdated = 8;
+}
+
+// Dashboard data message.
+message DashboardData {
+  // The payer account ID associated with the data.
+  string payerId = 1;
+
+  // The specific date this record summarizes (YYYY-MM-DD).
+  string currentDate = 2;
+
+  // Recommended hourly commitment for Savings Plan in USD.
+  double spRecommendation = 3;
+
+  // Estimated monthly savings from using Savings Plans in USD.
+  double estimatedSavings = 4;
+
+  // Estimated percentage savings compared to On-Demand costs.
+  double estimatedSavingsPercentage = 5;
+
+  // Total On-Demand usage in hours for the date.
+  double ondemandUsage = 6;
+
+  // Total On-Demand cost in USD for the date.
+  double ondemandCost = 7;
+  
+  // Total Reserved Instance usage in hours for the date.
+  double reservedUsage = 8;
+
+  // Total Reserved Instance cost in USD for the date.
+  double reservedCost = 9;
+
+  // Total Savings Plan usage in hours for the date.
+  double savingsPlanUsage = 10;
+
+  // Total Savings Plan cost in USD for the date.
+  double savingsPlanCost = 11;
+
+  // Total Spot Instance usage in hours for the date.
+  double spotUsage = 12;
+
+  // Total Spot Instance cost in USD for the date.
+  double spotCost = 13;
+
+  // Raw tags or metadata associated with the applied Savings Plan.
+  string spTags = 14;
+}
+
+// Response message for the Flow.GetDashboardData rpc.
+message GetDashboardDataResponse {
+  // List of daily dashboard data entries within the requested date range.
+  repeated DashboardData dashboardData = 1;
 }

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -31976,6 +31976,10 @@
         "spTags": {
           "type": "string",
           "description": "Raw tags or metadata associated with the applied Savings Plan."
+        },
+        "purchasedBy": {
+          "type": "string",
+          "description": "The user or system that purchased the Savings Plan."
         }
       },
       "description": "Dashboard data message."

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -7906,40 +7906,6 @@
         ]
       }
     },
-    "/v1/dashboard": {
-      "post": {
-        "summary": "Gets the data for the Flow Dashboard.",
-        "operationId": "Flow_GetDashboardData",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1GetDashboardDataResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "description": "Request message for the Flow.GetDashboardData rpc.",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1GetDashboardDataRequest"
-            }
-          }
-        ],
-        "tags": [
-          "Flow"
-        ]
-      }
-    },
     "/v1/discount": {
       "post": {
         "summary": "Get the discount recommendations for every account in a cost group",
@@ -10727,6 +10693,40 @@
         ],
         "tags": [
           "Cover"
+        ]
+      }
+    },
+    "/v1/recommendations/purchased": {
+      "post": {
+        "summary": "Gets the data for the Flow Dashboard.",
+        "operationId": "Flow_GetPurchasedRecommendationDetails",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetPurchasedRecommendationDetailsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Request message for the Flow.GetPurchasedRecommendationDetails rpc.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetPurchasedRecommendationDetailsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Flow"
         ]
       }
     },
@@ -31907,83 +31907,6 @@
         }
       }
     },
-    "v1DashboardData": {
-      "type": "object",
-      "properties": {
-        "payerId": {
-          "type": "string",
-          "description": "The payer account ID associated with the data."
-        },
-        "currentDate": {
-          "type": "string",
-          "description": "The specific date this record summarizes (YYYY-MM-DD)."
-        },
-        "spRecommendation": {
-          "type": "number",
-          "format": "double",
-          "description": "Recommended hourly commitment for Savings Plan in USD."
-        },
-        "estimatedSavings": {
-          "type": "number",
-          "format": "double",
-          "description": "Estimated monthly savings from using Savings Plans in USD."
-        },
-        "estimatedSavingsPercentage": {
-          "type": "number",
-          "format": "double",
-          "description": "Estimated percentage savings compared to On-Demand costs."
-        },
-        "ondemandUsage": {
-          "type": "number",
-          "format": "double",
-          "description": "Total On-Demand usage in hours for the date."
-        },
-        "ondemandCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Total On-Demand cost in USD for the date."
-        },
-        "reservedUsage": {
-          "type": "number",
-          "format": "double",
-          "description": "Total Reserved Instance usage in hours for the date."
-        },
-        "reservedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Total Reserved Instance cost in USD for the date."
-        },
-        "savingsPlanUsage": {
-          "type": "number",
-          "format": "double",
-          "description": "Total Savings Plan usage in hours for the date."
-        },
-        "savingsPlanCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Total Savings Plan cost in USD for the date."
-        },
-        "spotUsage": {
-          "type": "number",
-          "format": "double",
-          "description": "Total Spot Instance usage in hours for the date."
-        },
-        "spotCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Total Spot Instance cost in USD for the date."
-        },
-        "spTags": {
-          "type": "string",
-          "description": "Raw tags or metadata associated with the applied Savings Plan."
-        },
-        "purchasedBy": {
-          "type": "string",
-          "description": "The user or system that purchased the Savings Plan."
-        }
-      },
-      "description": "Dashboard data message."
-    },
     "v1DataAccess": {
       "type": "object",
       "properties": {
@@ -33364,38 +33287,6 @@
         "chargingTarget"
       ]
     },
-    "v1GetDashboardDataRequest": {
-      "type": "object",
-      "properties": {
-        "payerId": {
-          "type": "string",
-          "description": "The payer account ID to retrieve dashboard data for."
-        },
-        "startDate": {
-          "type": "string",
-          "description": "The start date of the dashboard range in YYYY-MM-DD format."
-        },
-        "endDate": {
-          "type": "string",
-          "description": "The end date of the dashboard range in YYYY-MM-DD format."
-        }
-      },
-      "description": "Request message for the Flow.GetDashboardData rpc."
-    },
-    "v1GetDashboardDataResponse": {
-      "type": "object",
-      "properties": {
-        "dashboardData": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1DashboardData"
-          },
-          "description": "List of daily dashboard data entries within the requested date range."
-        }
-      },
-      "description": "Response message for the Flow.GetDashboardData rpc."
-    },
     "v1GetDefaultCostAccessTemplateUrlResponse": {
       "type": "object",
       "properties": {
@@ -33766,6 +33657,38 @@
           }
         }
       }
+    },
+    "v1GetPurchasedRecommendationDetailsRequest": {
+      "type": "object",
+      "properties": {
+        "payerId": {
+          "type": "string",
+          "description": "The payer account ID to retrieve dashboard data for."
+        },
+        "startDate": {
+          "type": "string",
+          "description": "The start date of the dashboard range in YYYY-MM-DD format."
+        },
+        "endDate": {
+          "type": "string",
+          "description": "The end date of the dashboard range in YYYY-MM-DD format."
+        }
+      },
+      "description": "Request message for the Flow.GetPurchasedRecommendationDetails rpc."
+    },
+    "v1GetPurchasedRecommendationDetailsResponse": {
+      "type": "object",
+      "properties": {
+        "purchasedRecommendationDetails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PurchasedRecommendationDetails"
+          },
+          "description": "List of daily dashboard data entries within the requested date range."
+        }
+      },
+      "description": "Response message for the Flow.GetDashboardData rpc."
     },
     "v1GetRecommendationDetailsResponse": {
       "type": "object",
@@ -35494,6 +35417,83 @@
         }
       },
       "title": "Response message for PublishView"
+    },
+    "v1PurchasedRecommendationDetails": {
+      "type": "object",
+      "properties": {
+        "payerId": {
+          "type": "string",
+          "description": "The payer account ID associated with the data."
+        },
+        "currentDate": {
+          "type": "string",
+          "description": "The specific date this record summarizes (YYYY-MM-DD)."
+        },
+        "spRecommendation": {
+          "type": "number",
+          "format": "double",
+          "description": "Recommended hourly commitment for Savings Plan in USD."
+        },
+        "estimatedSavings": {
+          "type": "number",
+          "format": "double",
+          "description": "Estimated monthly savings from using Savings Plans in USD."
+        },
+        "estimatedSavingsPercentage": {
+          "type": "number",
+          "format": "double",
+          "description": "Estimated percentage savings compared to On-Demand costs."
+        },
+        "ondemandUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total On-Demand usage in hours for the date."
+        },
+        "ondemandCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total On-Demand cost in USD for the date."
+        },
+        "reservedUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Reserved Instance usage in hours for the date."
+        },
+        "reservedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Reserved Instance cost in USD for the date."
+        },
+        "savingsPlanUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Savings Plan usage in hours for the date."
+        },
+        "savingsPlanCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Savings Plan cost in USD for the date."
+        },
+        "spotUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Spot Instance usage in hours for the date."
+        },
+        "spotCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Spot Instance cost in USD for the date."
+        },
+        "spTags": {
+          "type": "string",
+          "description": "Raw tags or metadata associated with the applied Savings Plan."
+        },
+        "purchasedBy": {
+          "type": "string",
+          "description": "The user or system that purchased the Savings Plan."
+        }
+      },
+      "description": "Dashboard data message."
     },
     "v1ReadAdjustmentsRequestAwsOptions": {
       "type": "object",

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -7906,6 +7906,40 @@
         ]
       }
     },
+    "/v1/dashboard": {
+      "post": {
+        "summary": "Gets the data for the Flow Dashboard.",
+        "operationId": "Flow_GetDashboardData",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetDashboardDataResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Request message for the Flow.GetDashboardData rpc.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetDashboardDataRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Flow"
+        ]
+      }
+    },
     "/v1/discount": {
       "post": {
         "summary": "Get the discount recommendations for every account in a cost group",
@@ -27526,11 +27560,11 @@
       "properties": {
         "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
       "additionalProperties": {},
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "protobufNullValue": {
       "type": "string",
@@ -27538,7 +27572,7 @@
         "NULL_VALUE"
       ],
       "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     },
     "protosOperation": {
       "type": "object",
@@ -31873,6 +31907,79 @@
         }
       }
     },
+    "v1DashboardData": {
+      "type": "object",
+      "properties": {
+        "payerId": {
+          "type": "string",
+          "description": "The payer account ID associated with the data."
+        },
+        "currentDate": {
+          "type": "string",
+          "description": "The specific date this record summarizes (YYYY-MM-DD)."
+        },
+        "spRecommendation": {
+          "type": "number",
+          "format": "double",
+          "description": "Recommended hourly commitment for Savings Plan in USD."
+        },
+        "estimatedSavings": {
+          "type": "number",
+          "format": "double",
+          "description": "Estimated monthly savings from using Savings Plans in USD."
+        },
+        "estimatedSavingsPercentage": {
+          "type": "number",
+          "format": "double",
+          "description": "Estimated percentage savings compared to On-Demand costs."
+        },
+        "ondemandUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total On-Demand usage in hours for the date."
+        },
+        "ondemandCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total On-Demand cost in USD for the date."
+        },
+        "reservedUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Reserved Instance usage in hours for the date."
+        },
+        "reservedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Reserved Instance cost in USD for the date."
+        },
+        "savingsPlanUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Savings Plan usage in hours for the date."
+        },
+        "savingsPlanCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Savings Plan cost in USD for the date."
+        },
+        "spotUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Spot Instance usage in hours for the date."
+        },
+        "spotCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Total Spot Instance cost in USD for the date."
+        },
+        "spTags": {
+          "type": "string",
+          "description": "Raw tags or metadata associated with the applied Savings Plan."
+        }
+      },
+      "description": "Dashboard data message."
+    },
     "v1DataAccess": {
       "type": "object",
       "properties": {
@@ -33253,6 +33360,38 @@
         "chargingTarget"
       ]
     },
+    "v1GetDashboardDataRequest": {
+      "type": "object",
+      "properties": {
+        "payerId": {
+          "type": "string",
+          "description": "The payer account ID to retrieve dashboard data for."
+        },
+        "startDate": {
+          "type": "string",
+          "description": "The start date of the dashboard range in YYYY-MM-DD format."
+        },
+        "endDate": {
+          "type": "string",
+          "description": "The end date of the dashboard range in YYYY-MM-DD format."
+        }
+      },
+      "description": "Request message for the Flow.GetDashboardData rpc."
+    },
+    "v1GetDashboardDataResponse": {
+      "type": "object",
+      "properties": {
+        "dashboardData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1DashboardData"
+          },
+          "description": "List of daily dashboard data entries within the requested date range."
+        }
+      },
+      "description": "Response message for the Flow.GetDashboardData rpc."
+    },
     "v1GetDefaultCostAccessTemplateUrlResponse": {
       "type": "object",
       "properties": {
@@ -33874,38 +34013,49 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "title": "Unique ID of the settings entry"
         },
         "accountScope": {
-          "type": "string"
+          "type": "string",
+          "title": "Account scope for the settings (payer or linked)"
         },
         "customization": {
-          "type": "string"
+          "type": "string",
+          "title": "Customization setting for the Savings Plan"
         },
         "planTerm": {
-          "type": "string"
+          "type": "string",
+          "title": "Savings Plan term (e.g., ONE_YEAR, THREE_YEARS)"
         },
         "paymentOption": {
-          "type": "string"
+          "type": "string",
+          "title": "Payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT)"
         },
         "lookBackPeriod": {
-          "type": "string"
+          "type": "string",
+          "title": "Lookback period used for the Savings Plan recommendation (e.g., SEVEN_DAYS, THIRTY_DAYS, SIXTY_DAYS)"
         },
         "instanceFamily": {
-          "type": "string"
+          "type": "string",
+          "title": "Instance family for the Savings Plan, if applicable"
         },
         "annualBudget": {
           "type": "number",
-          "format": "double"
+          "format": "double",
+          "title": "Annual budget set for the Savings Plan"
         },
         "approval": {
-          "type": "boolean"
+          "type": "boolean",
+          "title": "Indicates whether the settings were approved by the payer"
         },
         "lastUpdated": {
-          "type": "string"
+          "type": "string",
+          "title": "The last updated timestamp for this settings entry, in RFC3339 UTC format"
         },
         "payerId": {
-          "type": "string"
+          "type": "string",
+          "title": "Payer account ID associated with the settings"
         }
       },
       "description": "Response message for fetching previous settings configuration of a user."
@@ -36223,35 +36373,45 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "Unique identifier for the settings history entry."
         },
         "accountScope": {
-          "type": "string"
+          "type": "string",
+          "description": "The account scope for the settings (payer or linked)."
         },
         "customization": {
-          "type": "string"
+          "type": "string",
+          "description": "The customization setting for the Savings Plan."
         },
         "planTerm": {
-          "type": "string"
+          "type": "string",
+          "description": "The term of the Savings Plan (e.g., ONE_YEAR, THREE_YEARS)."
         },
         "paymentOption": {
-          "type": "string"
+          "type": "string",
+          "description": "The payment option for the Savings Plan (e.g., ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT)."
         },
         "lookBackPeriod": {
-          "type": "string"
+          "type": "string",
+          "description": "The lookback period used for the Savings Plan recommendation."
         },
         "instanceFamily": {
-          "type": "string"
+          "type": "string",
+          "description": "The instance family for the Savings Plan, if applicable."
         },
         "annualBudget": {
           "type": "number",
-          "format": "double"
+          "format": "double",
+          "description": "The annual budget set for the Savings Plan."
         },
         "approval": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Indicates whether the settings were approved by the payer."
         },
         "lastUpdated": {
-          "type": "string"
+          "type": "string",
+          "description": "The last updated timestamp for this settings history entry, in RFC3339 UTC format."
         }
       },
       "description": "Settings history message."
@@ -36376,11 +36536,11 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "The id."
+          "description": "The id.\n\nThe currently supported thirdProfit items are as follows:\n`Miscellaneous`\n`CustomizedService`\n`AgencyFee`\n`SupportFee`"
         },
         "name": {
           "type": "string",
-          "description": "The name."
+          "description": "The name.\nA value equivalent to the id will be set."
         },
         "profit": {
           "type": "number",


### PR DESCRIPTION
- Add descriptive comments to existing API methods
- Add GetDashboardData RPC for retrieving per-day dashboard data (supports repeated entries)
