### PR TITLE
Add GetCrossAccountAccessDetails RPC and related messages

### DIFF
--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -641,12 +641,7 @@ message CrossAccountAccessDetail {
   // This can be `latest`, `outdated`, or some error information.
   string status = 6;
 
-  // The last updated timestamp, RFC3339 UTC.
-  string lastUpdated = 7;
+  // The access type:  "savings_plan_access" or "cost_explorer_access"
+  string access = 7;
 
-  // The access type- full access to view simulation and purchase saving plan: "savings_plan_access"
-  string access = 8;
-
-  // The parent identifier for hierarchical relationships.
-  string parent = 9;
 }

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -5293,7 +5293,7 @@
         "parameters": [
           {
             "name": "target",
-            "description": "Required. The target AWS account to validate.",
+            "description": "Required. The target AWS account to be checked.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -33538,17 +33538,9 @@
           "type": "string",
           "description": "This can be `latest`, `outdated`, or some error information."
         },
-        "lastUpdated": {
-          "type": "string",
-          "description": "The last updated timestamp, RFC3339 UTC."
-        },
         "access": {
           "type": "string",
-          "title": "The access type- full access to view simulation and purchase saving plan: \"savings_plan_access\""
-        },
-        "parent": {
-          "type": "string",
-          "description": "The parent identifier for hierarchical relationships."
+          "title": "The access type:  \"savings_plan_access\" or \"cost_explorer_access\""
         }
       },
       "description": "Individual cross-access detail record."


### PR DESCRIPTION
Introduce a new RPC for retrieving cross-account access details, update comments for clarity, and enhance API documentation for better understanding.