### PR TITLE
Add monthAndYear field to GetSPToPurchaseDetailsRequest and update Swagger documentation

### DIFF
--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -265,8 +265,8 @@ message CreateMessageToSlackRequest {
 message GetSPToPurchaseDetailsRequest {
    // Required. The id of the payer account.
   string payerId = 1;
-  // Required. The month and year for which the savings plan details are requested, formatted as "MM-YYYY".
-  string monthAndYear = 2;
+  // Required. The year and month  for which the savings plan details are requested, formatted as "YYYYMM".
+  string yearMonth  = 2;
 }
 
 // ##################################### RESPONSES #####################################

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -13233,8 +13233,8 @@
             "type": "string"
           },
           {
-            "name": "monthAndYear",
-            "description": "Required. The month and year for which the savings plan details are requested, formatted as \"MM-YYYY\".",
+            "name": "yearMonth",
+            "description": "Required. The year and month  for which the savings plan details are requested, formatted as \"YYYYMM\".",
             "in": "query",
             "required": false,
             "type": "string"


### PR DESCRIPTION
Introduce a new field for month and year in the request for savings plan details and enhance the Swagger documentation to reflect this change.