### PR TITLE
Add account name and CUR type fields to CalculationPrerequisite message

### DIFF
--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -2374,6 +2374,12 @@ message CalculationPrerequisite {
   
   // The unblended cost in CUR.
   double unblended_cost_in_cur = 4;
+
+  // The account name.
+  string name = 5;
+
+  // The CUR type, valid values are `legacy` and `2.0`.
+  string cur_type = 6;
 }
 
 message ListCalculationPrerequisitesResponse {

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -32095,6 +32095,14 @@
           "type": "number",
           "format": "double",
           "description": "The unblended cost in CUR."
+        },
+        "name": {
+          "type": "string",
+          "description": "The account name."
+        },
+        "curType": {
+          "type": "string",
+          "description": "The CUR type, valid values are `legacy` and `2.0`."
         }
       }
     },


### PR DESCRIPTION
Introduce account name and CUR type fields in the CalculationPrerequisite message and update the Swagger documentation accordingly.