### PR TITLE
Add CheckSPToPurchaseDetailsLinkExpiry RPC and update related messages

### DIFF
--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -373,7 +373,7 @@ message GetUserAccountSettingsRequest {
 
 // Request message for the Flow.CheckSPToPurchaseDetailsLinkExpiryRequest RPC
 message CheckSPToPurchaseDetailsLinkExpiryRequest {
-  //Required. The URL containing the expiry information to check.
+  // Required. The URL containing the expiry information to check.
   string url = 1; // The URL to check for expiration
 }
 
@@ -863,5 +863,5 @@ message CheckSPToPurchaseDetailsLinkExpiryResponse {
   bool isExpired = 1;          // Whether the link has expired
   string expiryDate = 2;       // The raw expiry date from the URL (ISO8601 format)
   string formattedDate = 3;    // User-friendly formatted date
-  string message = 4;           // Human readable status message
+  string message = 4;           // Human-readable status message
 }

--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -146,6 +146,14 @@ service Flow {
       get: "/v1/user/settings/{id}"
     };
   }
+
+   // Sends savings plan details to be purchased to a Slack channel or user email
+  rpc CheckSPToPurchaseDetailsLinkExpiry(CheckSPToPurchaseDetailsLinkExpiryRequest) returns (CheckSPToPurchaseDetailsLinkExpiryResponse) {
+    option (google.api.http) = {
+      get: "/v1/sp/purchaseDetails/notification/link/expiry"
+    };
+  }
+  
 }
 
 // ##################################### REQUESTS #####################################
@@ -330,6 +338,7 @@ message SavingsPlanDetailsPurchase {
   string reductionRate = 9; // Cost reduction percentage
   string approvalLink = 10; // Link for approval action
   string language = 11; // Language code (en or ja)
+  string linkExpiryDate = 12; // ISO8601 formatted date when the approval link expires (3 days from sending)
 
 }
 
@@ -360,6 +369,11 @@ message SetUserAccountSettingsRequest {
 message GetUserAccountSettingsRequest {
   // Required. The user ID of the user.
   string id = 1;
+}
+
+// Request message for the Flow.CheckSPToPurchaseDetailsLinkExpiryRequest RPC
+message CheckSPToPurchaseDetailsLinkExpiryRequest {
+  string url = 1; // The URL to check for expiration
 }
 
 // ##################################### RESPONSES #####################################
@@ -841,4 +855,12 @@ message GetUserAccountSettingsResponse {
 
   // Preferred language for the user interface.
   string language = 4;
+}
+
+// Response message for the Flow.CheckSPToPurchaseDetailsLinkExpiryRequest RPC
+message CheckSPToPurchaseDetailsLinkExpiryResponse {
+  bool isExpired = 1;          // Whether the link has expired
+  string expiryDate = 2;       // The raw expiry date from the URL (ISO8601 format)
+  string formattedDate = 3;    // User-friendly formatted date
+  string message = 4;           // Human readable status message
 }

--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -373,6 +373,7 @@ message GetUserAccountSettingsRequest {
 
 // Request message for the Flow.CheckSPToPurchaseDetailsLinkExpiryRequest RPC
 message CheckSPToPurchaseDetailsLinkExpiryRequest {
+  //Required. The URL containing the expiry information to check.
   string url = 1; // The URL to check for expiration
 }
 

--- a/flow/v1/flow.proto
+++ b/flow/v1/flow.proto
@@ -147,7 +147,7 @@ service Flow {
     };
   }
 
-   // Sends savings plan details to be purchased to a Slack channel or user email
+   // Checks the expiry of the link in the SP to purchase details notification
   rpc CheckSPToPurchaseDetailsLinkExpiry(CheckSPToPurchaseDetailsLinkExpiryRequest) returns (CheckSPToPurchaseDetailsLinkExpiryResponse) {
     option (google.api.http) = {
       get: "/v1/sp/purchaseDetails/notification/link/expiry"

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -13250,7 +13250,7 @@
     },
     "/v1/sp/purchaseDetails/notification/link/expiry": {
       "get": {
-        "summary": "Sends savings plan details to be purchased to a Slack channel or user email",
+        "summary": "Checks the expiry of the link in the SP to purchase details notification",
         "operationId": "Flow_CheckSPToPurchaseDetailsLinkExpiry",
         "responses": {
           "200": {

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -13269,7 +13269,7 @@
         "parameters": [
           {
             "name": "url",
-            "description": "The URL to check for expiration",
+            "description": "Required. The URL containing the expiry information to check.\n\nThe URL to check for expiration",
             "in": "query",
             "required": false,
             "type": "string"

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -13271,7 +13271,7 @@
             "name": "url",
             "description": "Required. The URL containing the expiry information to check.\n\nThe URL to check for expiration",
             "in": "query",
-            "required": false,
+            "required": true,
             "type": "string"
           }
         ],

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -13248,6 +13248,38 @@
         ]
       }
     },
+    "/v1/sp/purchaseDetails/notification/link/expiry": {
+      "get": {
+        "summary": "Sends savings plan details to be purchased to a Slack channel or user email",
+        "operationId": "Flow_CheckSPToPurchaseDetailsLinkExpiry",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CheckSPToPurchaseDetailsLinkExpiryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "description": "The URL to check for expiration",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Flow"
+        ]
+      }
+    },
     "/v1/sp/purchaseDetails/{payerId}/{yearMonth}": {
       "get": {
         "summary": "Get savings plan details to be purchased .",
@@ -32683,6 +32715,28 @@
         }
       }
     },
+    "v1CheckSPToPurchaseDetailsLinkExpiryResponse": {
+      "type": "object",
+      "properties": {
+        "isExpired": {
+          "type": "boolean",
+          "title": "Whether the link has expired"
+        },
+        "expiryDate": {
+          "type": "string",
+          "title": "The raw expiry date from the URL (ISO8601 format)"
+        },
+        "formattedDate": {
+          "type": "string",
+          "title": "User-friendly formatted date"
+        },
+        "message": {
+          "type": "string",
+          "title": "Human readable status message"
+        }
+      },
+      "title": "Response message for the Flow.CheckSPToPurchaseDetailsLinkExpiryRequest RPC"
+    },
     "v1CloudWatchMetricsStream": {
       "type": "object",
       "properties": {
@@ -39450,6 +39504,10 @@
         "language": {
           "type": "string",
           "title": "Language code (en or ja)"
+        },
+        "linkExpiryDate": {
+          "type": "string",
+          "title": "ISO8601 formatted date when the approval link expires (3 days from sending)"
         }
       },
       "description": "Request message for the Flow.SendSPToPurchaseDetailsNotifications rpc."


### PR DESCRIPTION
Introduce a new RPC to check the expiration of savings plan purchase detail links and update related message structures accordingly.