### PR TITLE
Feat/ri sp export

### DIFF
--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -1814,6 +1814,10 @@ message GetCostReductionResponse {
 }
 
 message GetExportRISPRequest {  
+  message Columns {
+    repeated string values = 1;
+  }
+
   // Required. For AWS, "ri" or "sp".
   string type = 1;
   // Usually the language of the user information is used, 
@@ -1826,6 +1830,13 @@ message GetExportRISPRequest {
   string month = 4 [(google.api.field_behavior) = OPTIONAL];
   // Optional. Columns to include in the CSV output. Empty means all columns.
   repeated string columns = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Optional report names to generate.
+  // Valid values: ri_summary, sp_summary, ri_usageaccount, sp_usageaccount.
+  repeated string queries = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Optional per-query columns map. When set, values override `columns` for the matching query.
+  map<string, Columns> columnsByQuery = 7;
+  // Optional. When true, only the invoice-finalization gate is checked and no export email is sent.
+  bool checkOnly = 8;
 }
 
 // Request message for the ExportBillingGroupInvoiceServiceDiscounts rpc.
@@ -2113,6 +2124,8 @@ message ExportCostFiltersFileRequest {
 
   // Optional. If set to true, stream will include resource tags. 
   bool includeTags = 7;
+  // Optional. List of notification channel IDs to send the export result to.
+  repeated string notificationChannelIds = 8;
 }
 
 // Response message for the ExportCostFiltersFile rpc.

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -1822,6 +1822,10 @@ message GetExportRISPRequest {
   string language = 2 [(google.api.field_behavior) = OPTIONAL];
   // Required. Include expired
   bool includeExpired = 3;
+  // Optional. Target export month in YYYY-MM format. Defaults to current month if empty.
+  string month = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Optional. Columns to include in the CSV output. Empty means all columns.
+  repeated string columns = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Request message for the ExportBillingGroupInvoiceServiceDiscounts rpc.
@@ -1829,6 +1833,8 @@ message GetExportRISPResponse {
   // csv direct download link
   // expires in 10 minutes
   string downloadLink = 1;
+  // True when the export CSV was sent as an email attachment to configured recipients.
+  bool emailSent = 2;
 }
 
 // Request message for GetUtilization

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -1830,13 +1830,24 @@ message GetExportRISPRequest {
   string month = 4 [(google.api.field_behavior) = OPTIONAL];
   // Optional. Columns to include in the CSV output. Empty means all columns.
   repeated string columns = 5 [(google.api.field_behavior) = OPTIONAL];
-  // Optional report names to generate.
+  // Optional. Report names to generate. When empty, defaults to the reports matching `type`:
+  // - type=ri: ri_summary, ri_usageaccount
+  // - type=sp: sp_summary, sp_usageaccount
+  // - type=all: ri_summary, sp_summary, ri_usageaccount, sp_usageaccount
   // Valid values: ri_summary, sp_summary, ri_usageaccount, sp_usageaccount.
   repeated string queries = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Optional per-query columns map. When set, values override `columns` for the matching query.
+  // Optional. Per-query column overrides. When set, the specified columns are used instead of `columns`
+  // for the matching query. Valid keys are the same as the `queries` values:
+  // ri_summary, sp_summary, ri_usageaccount, sp_usageaccount.
   map<string, Columns> columnsByQuery = 7;
-  // Optional. When true, only the invoice-finalization gate is checked and no export email is sent.
+  // Optional. Dry-run mode: only checks whether the invoice calculation has been finalized
+  // for the requested MSP and month. No CSV is generated and no email is sent.
+  // Intended for UI use to determine if the export action should be enabled before calling
+  // without this flag.
   bool checkOnly = 8;
+  // Optional. Notification channel IDs to send the export email to.
+  // When set, overrides the default notification channel configured for the MSP.
+  repeated string notificationChannelIds = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Request message for the ExportBillingGroupInvoiceServiceDiscounts rpc.

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -2105,9 +2105,6 @@ message ExportCostFiltersFileRequest {
   // Required. Filter Id.
   string filterId = 2;
 
-  // Required. The channel ids to use for notifications.
-  repeated string notificationChannelIds = 8;
-
   // Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`.
   string startTime = 3;
 

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -23991,13 +23991,6 @@
     "CostExportCostFiltersFileBody": {
       "type": "object",
       "properties": {
-        "notificationChannelIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Required. The channel ids to use for notifications."
-        },
         "startTime": {
           "type": "string",
           "description": "Optional. The UTC date to start streaming data from. If not set, the first day of the current month will be used. Format: `yyyymmdd`. The oldest supported date is `20200101`."
@@ -24017,6 +24010,13 @@
         "includeTags": {
           "type": "boolean",
           "description": "Optional. If set to true, stream will include resource tags."
+        },
+        "notificationChannelIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. List of notification channel IDs to send the export result to."
         }
       },
       "description": "Request message for the ExportCostFiltersFile rpc."
@@ -25798,6 +25798,17 @@
         "name": {
           "type": "string"
         },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GetExportRISPRequestColumns": {
+      "type": "object",
+      "properties": {
         "values": {
           "type": "array",
           "items": {
@@ -42548,6 +42559,35 @@
         "includeExpired": {
           "type": "boolean",
           "title": "Required. Include expired"
+        },
+        "month": {
+          "type": "string",
+          "description": "Optional. Target export month in YYYY-MM format. Defaults to current month if empty."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Columns to include in the CSV output. Empty means all columns."
+        },
+        "queries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional report names to generate.\nValid values: ri_summary, sp_summary, ri_usageaccount, sp_usageaccount."
+        },
+        "columnsByQuery": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/GetExportRISPRequestColumns"
+          },
+          "description": "Optional per-query columns map. When set, values override `columns` for the matching query."
+        },
+        "checkOnly": {
+          "type": "boolean",
+          "description": "Optional. When true, only the invoice-finalization gate is checked and no export email is sent."
         }
       }
     },
@@ -42557,6 +42597,10 @@
         "downloadLink": {
           "type": "string",
           "title": "csv direct download link\nexpires in 10 minutes"
+        },
+        "emailSent": {
+          "type": "boolean",
+          "description": "True when the export CSV was sent as an email attachment to configured recipients."
         }
       },
       "description": "Request message for the ExportBillingGroupInvoiceServiceDiscounts rpc."


### PR DESCRIPTION
for reference https://github.com/mobingilabs/ouchan/pull/5741

This PR adds and enhances support for exporting Reserved Instance (RI) and Savings Plan (SP) reports, aligning the BlueAPI proto definitions with the requirements of the ouchan feature for RI/SP export

**Details**
- Adds optional fields to GetExportRISPRequest for specifying export month, columns, queries, and per-query columns, as well as a checkOnly flag.
- Adds an emailSent field to GetExportRISPResponse to indicate if the export was emailed.
- Updates ExportCostFiltersFileRequest to support multiple notification channel IDs.
- Removes a duplicate notificationChannelIds field to resolve proto compilation errors.
- Regenerates apidocs.swagger.json to reflect these changes.