### PR TITLE
feat(cost): Add ExportReport RPC with multi-vendor support

### DIFF
--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -561,6 +561,17 @@ service Cost {
     };
   }
 
+  // Queues a vendor report export and delivers results via email notification channel.
+  // Supports multiple report types per vendor. For AWS, this covers RI/SP utilization reports.
+  // The invoice calculation for the requested month must be finalized before calling this RPC.
+  // Use check_only=true to verify finalization without generating CSVs or sending email.
+  rpc ExportReport(ExportReportRequest) returns (ExportReportResponse) {
+    option (google.api.http) = {
+      post: "/v1/{vendor}/export/reports:queue"
+      body: "*"
+    };
+  }
+
   // Get the utilization details for an organization (or MSP).
   rpc GetUtilization(GetUtilizationRequest) returns (GetUtilizationResponse) {
     option (google.api.http) = {
@@ -1829,6 +1840,67 @@ message GetExportRISPResponse {
   // csv direct download link
   // expires in 10 minutes
   string downloadLink = 1;
+}
+
+// Request message for ExportReport.
+message ExportReportRequest {
+  // Required. Cloud vendor. Currently only "aws" is supported.
+  string vendor = 1;
+
+  // Required. Billing month in YYYY-MM format.
+  string month = 2;
+
+  // Optional. Dry-run mode: verify that the invoice calculation is finalized
+  // for the requested month without generating CSVs or sending email.
+  bool check_only = 3;
+
+  // Optional. Notification channel IDs to deliver the report.
+  // If empty, the MSP default notification channel configured in DynamoDB is used.
+  repeated string notification_channel_ids = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Vendor-specific report options. Must match the vendor field above.
+  oneof vendor_options {
+    AwsRispExportOptions aws_risp = 10;
+    // Future vendors can be added here, e.g.:
+    // AzureExportOptions azure_risp = 11;
+  }
+}
+
+// AWS RI/SP export options for ExportReport.
+message AwsRispExportOptions {
+  // Per-report column filter container.
+  message Columns {
+    repeated string values = 1;
+  }
+
+  // Optional. Include expired RIs/SPs in the results. Default: false.
+  bool include_expired = 1;
+
+  // Optional. CSV header language: "en" or "ja". Default: "en".
+  string language = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Report queries to include in the export.
+  // Valid values: "ri_summary", "sp_summary", "ri_usageaccount", "sp_usageaccount".
+  // Default when empty: all 4 reports are included.
+  repeated string queries = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Global column filter applied to all reports.
+  // Superseded per-report by columns_by_query if that key is present.
+  repeated string columns = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Per-report column overrides.
+  // Keys must be valid query names (ri_summary, sp_summary, ri_usageaccount, sp_usageaccount).
+  map<string, Columns> columns_by_query = 5;
+}
+
+// Response message for ExportReport.
+message ExportReportResponse {
+  // True if the export email was successfully queued for delivery.
+  bool email_sent = 1;
+
+  // Only meaningful when check_only=true in the request.
+  // True if the invoice calculation is finalized for the requested month.
+  bool finalized = 2;
 }
 
 // Request message for GetUtilization

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -561,11 +561,11 @@ service Cost {
     };
   }
 
-  // Queues a vendor report export and delivers results via email notification channel.
+  // Exports a vendor report and delivers results via email notification channel.
   // Supports multiple report types per vendor. For AWS, this covers RI/SP utilization reports.
   rpc ExportReport(ExportReportRequest) returns (ExportReportResponse) {
     option (google.api.http) = {
-      post: "/v1/{vendor}/export/reports:queue"
+      post: "/v1/reports:export"
       body: "*"
     };
   }
@@ -1842,13 +1842,13 @@ message GetExportRISPResponse {
 
 // Request message for ExportReport.
 message ExportReportRequest {
+  // Required. Billing month in YYYY-MM format.
+  string month = 2;
+
   // Optional. Cloud vendor.
   // Accepted values: "aws", "gcp", "azure".
   // If empty, defaults to "aws" for backward compatibility.
   string vendor = 1;
-
-  // Required. Billing month in YYYY-MM format.
-  string month = 2;
 
   // Optional. Notification channel IDs to deliver the report.
   // If empty, the MSP default notification channel configured in DynamoDB is used.
@@ -1869,13 +1869,13 @@ message AwsRispExportOptions {
   // Optional. Include expired RIs/SPs in the results. Default: false.
   bool include_expired = 1;
 
-  // Optional. CSV header language: "en" or "ja". Default: "en".
+  // Optional. CSV header language: "en" or "ja".
+  // If empty, defaults to the MSP or login user's language.
   string language = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. Report queries to include in the export.
+  // Required. Report queries to include in the export. Must contain at least 1 value.
   // Valid values: "ri_summary", "sp_summary", "ri_usageaccount", "sp_usageaccount".
-  // Default when empty: all 4 reports are included.
-  repeated string queries = 3 [(google.api.field_behavior) = OPTIONAL];
+  repeated string queries = 3 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. Global column filter applied to all reports.
   // Superseded per-report by columns_by_query if that key is present.

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -1842,7 +1842,9 @@ message GetExportRISPResponse {
 
 // Request message for ExportReport.
 message ExportReportRequest {
-  // Required. Cloud vendor. Currently only "aws" is supported.
+  // Optional. Cloud vendor.
+  // Accepted values: "aws", "gcp", "azure".
+  // If empty, defaults to "aws" for backward compatibility.
   string vendor = 1;
 
   // Required. Billing month in YYYY-MM format.
@@ -1854,8 +1856,7 @@ message ExportReportRequest {
 
   // Optional. Valid only for the `aws` vendor. AWS RI/SP export options.
   AwsRispExportOptions aws_options = 10;
-  // Future vendors follow the same pattern, e.g.:
-  // AzureRispExportOptions azure_options = 11;
+  // Future vendor-specific options follow the same pattern (e.g. gcp_options, azure_options).
 }
 
 // AWS RI/SP export options for ExportReport.

--- a/cost/v1/cost.proto
+++ b/cost/v1/cost.proto
@@ -563,8 +563,6 @@ service Cost {
 
   // Queues a vendor report export and delivers results via email notification channel.
   // Supports multiple report types per vendor. For AWS, this covers RI/SP utilization reports.
-  // The invoice calculation for the requested month must be finalized before calling this RPC.
-  // Use check_only=true to verify finalization without generating CSVs or sending email.
   rpc ExportReport(ExportReportRequest) returns (ExportReportResponse) {
     option (google.api.http) = {
       post: "/v1/{vendor}/export/reports:queue"
@@ -1850,20 +1848,14 @@ message ExportReportRequest {
   // Required. Billing month in YYYY-MM format.
   string month = 2;
 
-  // Optional. Dry-run mode: verify that the invoice calculation is finalized
-  // for the requested month without generating CSVs or sending email.
-  bool check_only = 3;
-
   // Optional. Notification channel IDs to deliver the report.
   // If empty, the MSP default notification channel configured in DynamoDB is used.
   repeated string notification_channel_ids = 4 [(google.api.field_behavior) = OPTIONAL];
 
-  // Vendor-specific report options. Must match the vendor field above.
-  oneof vendor_options {
-    AwsRispExportOptions aws_risp = 10;
-    // Future vendors can be added here, e.g.:
-    // AzureExportOptions azure_risp = 11;
-  }
+  // Optional. Valid only for the `aws` vendor. AWS RI/SP export options.
+  AwsRispExportOptions aws_options = 10;
+  // Future vendors follow the same pattern, e.g.:
+  // AzureRispExportOptions azure_options = 11;
 }
 
 // AWS RI/SP export options for ExportReport.
@@ -1897,10 +1889,6 @@ message AwsRispExportOptions {
 message ExportReportResponse {
   // True if the export email was successfully queued for delivery.
   bool email_sent = 1;
-
-  // Only meaningful when check_only=true in the request.
-  // True if the invoice calculation is finalized for the requested month.
-  bool finalized = 2;
 }
 
 // Request message for GetUtilization

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -153,7 +153,7 @@
                   "$ref": "#/definitions/v1ListAccountGroupsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListAccountGroupsResponse"
@@ -162,7 +162,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -185,7 +185,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -216,7 +216,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -250,7 +250,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -283,7 +283,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -304,7 +304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -338,7 +338,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -368,7 +368,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -402,7 +402,7 @@
                   "$ref": "#/definitions/v1DefaultCostAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1DefaultCostAccess"
@@ -411,7 +411,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -434,7 +434,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -465,7 +465,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -495,7 +495,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -528,7 +528,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -561,7 +561,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -592,7 +592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -613,7 +613,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -647,7 +647,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -684,7 +684,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -714,7 +714,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -754,7 +754,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -788,7 +788,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -809,7 +809,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -843,7 +843,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -858,13 +858,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiNotification"
+              "$ref": "#/definitions/blueapiApiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -892,13 +892,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiNotification"
+              "$ref": "#/definitions/blueapiApiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -936,7 +936,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -967,13 +967,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiNotification"
+              "$ref": "#/definitions/blueapiApiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1013,7 +1013,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1042,7 +1042,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1075,7 +1075,7 @@
                   "$ref": "#/definitions/v1Announcement"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Announcement"
@@ -1084,7 +1084,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1116,7 +1116,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1163,7 +1163,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1210,7 +1210,7 @@
                   "$ref": "#/definitions/apiApiClient"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of apiApiClient"
@@ -1219,7 +1219,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1240,7 +1240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1275,7 +1275,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1307,7 +1307,7 @@
                   "$ref": "#/definitions/apiGroupRootUser"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of apiGroupRootUser"
@@ -1316,7 +1316,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1337,7 +1337,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1370,7 +1370,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1400,7 +1400,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1432,7 +1432,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1462,7 +1462,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1501,7 +1501,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1523,7 +1523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1558,7 +1558,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1590,7 +1590,7 @@
                   "$ref": "#/definitions/v1IpFilter"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1IpFilter"
@@ -1599,7 +1599,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1620,7 +1620,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1655,7 +1655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1687,7 +1687,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1726,7 +1726,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1758,7 +1758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1798,7 +1798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1838,7 +1838,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1872,7 +1872,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1905,7 +1905,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1938,7 +1938,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1971,7 +1971,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -1995,13 +1995,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiRole"
+              "$ref": "#/definitions/blueapiApiRole"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2036,7 +2036,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2067,13 +2067,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiRole"
+              "$ref": "#/definitions/blueapiApiRole"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2120,7 +2120,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2150,7 +2150,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2182,7 +2182,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2213,19 +2213,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiapiUser"
+                  "$ref": "#/definitions/blueapiApiUser"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapiapiUser"
+              "title": "Stream result of blueapiApiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2240,13 +2240,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiUser"
+              "$ref": "#/definitions/blueapiApiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2274,13 +2274,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiUser"
+              "$ref": "#/definitions/blueapiApiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2310,7 +2310,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2336,13 +2336,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiUser"
+              "$ref": "#/definitions/blueapiApiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2366,7 +2366,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2406,7 +2406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2437,7 +2437,7 @@
                   "$ref": "#/definitions/protosOperation"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of protosOperation"
@@ -2446,7 +2446,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2492,7 +2492,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2523,7 +2523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2556,7 +2556,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2590,13 +2590,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apirippleOrg"
+              "$ref": "#/definitions/apiRippleOrg"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2618,7 +2618,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2633,13 +2633,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiorgv1CreateOrgResponse"
+              "$ref": "#/definitions/blueapiOrgV1CreateOrgResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2650,7 +2650,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/blueapiorgv1CreateOrgRequest"
+              "$ref": "#/definitions/blueapiOrgV1CreateOrgRequest"
             }
           }
         ],
@@ -2674,7 +2674,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2709,7 +2709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2744,7 +2744,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2768,7 +2768,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2799,7 +2799,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2816,13 +2816,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapipricingv1GetInfoResponse"
+              "$ref": "#/definitions/blueapiPricingV1GetInfoResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2845,7 +2845,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2885,7 +2885,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2914,19 +2914,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/apirippleAccessGroup"
+                  "$ref": "#/definitions/apiRippleAccessGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of apirippleAccessGroup"
+              "title": "Stream result of apiRippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2950,13 +2950,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apirippleAccessGroup"
+              "$ref": "#/definitions/apiRippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -2990,7 +2990,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3029,7 +3029,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3053,13 +3053,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apirippleAccessGroup"
+              "$ref": "#/definitions/apiRippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3100,7 +3100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3134,7 +3134,7 @@
                   "$ref": "#/definitions/v1DataAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1DataAccess"
@@ -3143,7 +3143,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3166,7 +3166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3189,7 +3189,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3234,7 +3234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3279,7 +3279,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3319,7 +3319,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3356,7 +3356,7 @@
                   "$ref": "#/definitions/v1Activity"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Activity"
@@ -3365,7 +3365,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3398,7 +3398,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3429,7 +3429,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3460,7 +3460,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3498,7 +3498,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3537,7 +3537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3571,7 +3571,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3606,7 +3606,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3639,7 +3639,7 @@
                   "$ref": "#/definitions/v1AnomalyAlertData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AnomalyAlertData"
@@ -3648,7 +3648,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3671,7 +3671,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3702,7 +3702,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3733,7 +3733,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3773,7 +3773,7 @@
                   "$ref": "#/definitions/v1GetAlertsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetAlertsResponse"
@@ -3782,7 +3782,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3803,7 +3803,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3836,7 +3836,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3866,7 +3866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3896,7 +3896,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3937,7 +3937,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -3970,7 +3970,7 @@
                   "$ref": "#/definitions/v1DiscountExpiryAlertData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1DiscountExpiryAlertData"
@@ -3979,7 +3979,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4002,7 +4002,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4033,7 +4033,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4064,7 +4064,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4105,7 +4105,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4137,7 +4137,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4168,7 +4168,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4209,7 +4209,7 @@
                   "$ref": "#/definitions/v1BudgetAlerts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1BudgetAlerts"
@@ -4218,7 +4218,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4252,7 +4252,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4261,7 +4261,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4295,7 +4295,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4304,7 +4304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4338,7 +4338,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4347,7 +4347,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4378,19 +4378,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverv1FeeDetails"
+                  "$ref": "#/definitions/coverV1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of coverv1FeeDetails"
+              "title": "Stream result of coverV1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4421,19 +4421,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverv1FeeDetails"
+                  "$ref": "#/definitions/coverV1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of coverv1FeeDetails"
+              "title": "Stream result of coverV1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4464,19 +4464,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverv1FeeDetails"
+                  "$ref": "#/definitions/coverV1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of coverv1FeeDetails"
+              "title": "Stream result of coverV1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4510,7 +4510,7 @@
                   "$ref": "#/definitions/v1FeeItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1FeeItem"
@@ -4519,7 +4519,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4553,7 +4553,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4562,7 +4562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4596,7 +4596,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4605,7 +4605,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4639,7 +4639,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4648,7 +4648,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4682,7 +4682,7 @@
                   "$ref": "#/definitions/v1AllocationItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AllocationItem"
@@ -4691,7 +4691,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4725,7 +4725,7 @@
                   "$ref": "#/definitions/v1CostAllocatorDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1CostAllocatorDetails"
@@ -4734,7 +4734,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4755,7 +4755,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4789,7 +4789,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4820,7 +4820,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4858,7 +4858,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4888,7 +4888,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4927,7 +4927,7 @@
                   "$ref": "#/definitions/v1AnomalyData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AnomalyData"
@@ -4936,7 +4936,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -4968,7 +4968,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5007,7 +5007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5057,19 +5057,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapicoverv1Resource"
+                  "$ref": "#/definitions/blueapiCoverV1Resource"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapicoverv1Resource"
+              "title": "Stream result of blueapiCoverV1Resource"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5103,7 +5103,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5136,7 +5136,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5166,7 +5166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5200,7 +5200,7 @@
                   "$ref": "#/definitions/v1AccountAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AccountAccess"
@@ -5209,7 +5209,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5243,7 +5243,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5277,7 +5277,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5311,7 +5311,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5341,7 +5341,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5374,7 +5374,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5408,7 +5408,7 @@
                   "$ref": "#/definitions/v1AwsDailyRunHistory"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AwsDailyRunHistory"
@@ -5417,7 +5417,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5451,7 +5451,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5472,7 +5472,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5506,7 +5506,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5527,7 +5527,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5561,7 +5561,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5593,7 +5593,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5633,7 +5633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5667,7 +5667,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5700,7 +5700,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5724,7 +5724,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5758,7 +5758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5792,7 +5792,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5826,7 +5826,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5865,7 +5865,7 @@
                   "$ref": "#/definitions/v1ListBillingGroupCustomFieldResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListBillingGroupCustomFieldResponse"
@@ -5874,7 +5874,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5907,7 +5907,7 @@
                   "$ref": "#/definitions/v1GetBillingGroupAnnouncementsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetBillingGroupAnnouncementsResponse"
@@ -5916,7 +5916,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5949,7 +5949,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -5983,7 +5983,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6014,7 +6014,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6052,7 +6052,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6100,7 +6100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6148,7 +6148,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6188,7 +6188,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6228,7 +6228,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6268,7 +6268,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6308,7 +6308,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6348,7 +6348,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6388,7 +6388,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6424,19 +6424,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/billingv1BillingGroup"
+                  "$ref": "#/definitions/billingV1BillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of billingv1BillingGroup"
+              "title": "Stream result of billingV1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6488,13 +6488,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/billingv1BillingGroup"
+              "$ref": "#/definitions/billingV1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6528,7 +6528,7 @@
                   "$ref": "#/definitions/v1AbcBillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AbcBillingGroup"
@@ -6537,7 +6537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6569,7 +6569,7 @@
                   "$ref": "#/definitions/v1AbcAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AbcAccount"
@@ -6578,7 +6578,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6617,7 +6617,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6650,7 +6650,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6680,7 +6680,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6710,7 +6710,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6750,7 +6750,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6790,7 +6790,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6821,7 +6821,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6861,7 +6861,7 @@
                   "$ref": "#/definitions/v1AccountInvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AccountInvoiceServiceDiscounts"
@@ -6870,7 +6870,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6903,7 +6903,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6943,7 +6943,7 @@
                   "$ref": "#/definitions/v1ChildBillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ChildBillingGroup"
@@ -6952,7 +6952,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -6985,7 +6985,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7022,7 +7022,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7080,7 +7080,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7111,7 +7111,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7138,13 +7138,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/billingv1BillingGroup"
+              "$ref": "#/definitions/billingV1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7178,7 +7178,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7217,7 +7217,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7257,7 +7257,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7290,7 +7290,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7323,7 +7323,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7420,7 +7420,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7453,7 +7453,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7483,7 +7483,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7513,7 +7513,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7553,7 +7553,7 @@
                   "$ref": "#/definitions/v1ListBudgetsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListBudgetsResponse"
@@ -7562,7 +7562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7595,7 +7595,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7626,7 +7626,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7659,7 +7659,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7689,7 +7689,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7719,7 +7719,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7759,7 +7759,7 @@
                   "$ref": "#/definitions/v1GetChannelsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetChannelsResponse"
@@ -7768,7 +7768,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7801,7 +7801,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7835,7 +7835,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7858,7 +7858,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7897,7 +7897,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7920,7 +7920,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7943,7 +7943,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -7975,7 +7975,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8015,7 +8015,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8046,7 +8046,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8079,7 +8079,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8130,7 +8130,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8161,7 +8161,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8188,13 +8188,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apilusterLabel"
+              "$ref": "#/definitions/apiLusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8229,7 +8229,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8253,13 +8253,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apilusterLabel"
+              "$ref": "#/definitions/apiLusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8296,19 +8296,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/apilusterLabel"
+                  "$ref": "#/definitions/apiLusterLabel"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of apilusterLabel"
+              "title": "Stream result of apiLusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8342,7 +8342,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8382,7 +8382,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8430,7 +8430,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8474,7 +8474,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8528,7 +8528,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8573,7 +8573,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8610,7 +8610,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8657,7 +8657,7 @@
                   "$ref": "#/definitions/lusterContext"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of lusterContext"
@@ -8666,7 +8666,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8706,7 +8706,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8727,7 +8727,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8759,7 +8759,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8791,7 +8791,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8821,7 +8821,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8853,7 +8853,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8893,7 +8893,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8933,7 +8933,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -8973,7 +8973,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9013,7 +9013,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9053,7 +9053,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9093,7 +9093,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9133,7 +9133,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9173,7 +9173,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9213,7 +9213,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9252,7 +9252,7 @@
                   "$ref": "#/definitions/v1GetCostUsageV2Response"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetCostUsageV2Response"
@@ -9261,7 +9261,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9291,19 +9291,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapicoverv1CostItem"
+                  "$ref": "#/definitions/blueapiCoverV1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapicoverv1CostItem"
+              "title": "Stream result of blueapiCoverV1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9336,7 +9336,7 @@
                   "$ref": "#/definitions/v1Credit"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Credit"
@@ -9345,7 +9345,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9368,7 +9368,7 @@
                   "$ref": "#/definitions/v1CsvSetting"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1CsvSetting"
@@ -9377,7 +9377,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9400,7 +9400,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9434,7 +9434,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9463,7 +9463,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9502,7 +9502,7 @@
                   "$ref": "#/definitions/v1CustomField"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1CustomField"
@@ -9511,7 +9511,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9544,7 +9544,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9578,7 +9578,7 @@
                   "$ref": "#/definitions/v1GetCustomizedBillingServiceBillingGroupResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetCustomizedBillingServiceBillingGroupResponse"
@@ -9587,7 +9587,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9625,7 +9625,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9663,7 +9663,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9710,7 +9710,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9748,7 +9748,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9778,7 +9778,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9818,7 +9818,7 @@
                   "$ref": "#/definitions/rippleCustomizedBillingService"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of rippleCustomizedBillingService"
@@ -9827,7 +9827,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9861,7 +9861,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9894,7 +9894,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9927,7 +9927,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -9961,7 +9961,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10002,7 +10002,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10050,7 +10050,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10090,7 +10090,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10122,7 +10122,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10161,7 +10161,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10193,7 +10193,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10225,7 +10225,7 @@
                   "$ref": "#/definitions/v1GetCostForecastsDataResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetCostForecastsDataResponse"
@@ -10234,7 +10234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10266,7 +10266,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10295,7 +10295,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10324,7 +10324,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10363,7 +10363,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10397,7 +10397,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10430,7 +10430,7 @@
                   "$ref": "#/definitions/v1GetFreeFormatResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetFreeFormatResponse"
@@ -10439,7 +10439,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10477,7 +10477,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10514,7 +10514,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10547,7 +10547,7 @@
                   "$ref": "#/definitions/lusterHub"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of lusterHub"
@@ -10556,7 +10556,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10584,13 +10584,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiflowv1GetInfoResponse"
+              "$ref": "#/definitions/blueapiFlowV1GetInfoResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10612,7 +10612,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10634,7 +10634,7 @@
                   "$ref": "#/definitions/v1IntegrationStatus"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1IntegrationStatus"
@@ -10643,7 +10643,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10676,7 +10676,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10709,7 +10709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10742,7 +10742,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10764,7 +10764,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10799,7 +10799,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10839,7 +10839,7 @@
                   "$ref": "#/definitions/apiInvoiceMessage"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of apiInvoiceMessage"
@@ -10848,7 +10848,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10888,7 +10888,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10920,7 +10920,7 @@
                   "$ref": "#/definitions/v1ListInvoiceTemplateResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListInvoiceTemplateResponse"
@@ -10929,7 +10929,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10952,7 +10952,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -10992,7 +10992,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11032,7 +11032,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11072,7 +11072,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11113,7 +11113,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11153,7 +11153,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11194,7 +11194,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11234,7 +11234,7 @@
                   "$ref": "#/definitions/v1ListInvoiceResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListInvoiceResponse"
@@ -11243,7 +11243,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11277,7 +11277,7 @@
                   "$ref": "#/definitions/v1TotalSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1TotalSection"
@@ -11286,7 +11286,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11320,7 +11320,7 @@
                   "$ref": "#/definitions/v1BillingGroupSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1BillingGroupSection"
@@ -11329,7 +11329,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11363,7 +11363,7 @@
                   "$ref": "#/definitions/v1OverViewSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1OverViewSection"
@@ -11372,7 +11372,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11406,7 +11406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11428,7 +11428,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11450,7 +11450,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11488,7 +11488,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11510,7 +11510,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11532,7 +11532,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11571,7 +11571,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11604,7 +11604,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11627,7 +11627,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11660,7 +11660,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11693,7 +11693,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11726,7 +11726,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11759,7 +11759,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11792,7 +11792,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11825,7 +11825,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11858,7 +11858,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11891,7 +11891,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11924,7 +11924,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11957,7 +11957,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -11990,7 +11990,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12013,7 +12013,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12045,7 +12045,7 @@
                   "$ref": "#/definitions/v1Member"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Member"
@@ -12054,7 +12054,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12087,7 +12087,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12108,7 +12108,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12141,7 +12141,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12174,7 +12174,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12207,7 +12207,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12240,7 +12240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12273,7 +12273,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12306,7 +12306,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12339,7 +12339,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12369,7 +12369,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12409,7 +12409,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12442,7 +12442,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12475,7 +12475,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12505,7 +12505,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12537,7 +12537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12569,7 +12569,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12609,7 +12609,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12649,7 +12649,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12682,7 +12682,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12715,7 +12715,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12747,7 +12747,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12803,7 +12803,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12859,7 +12859,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12892,7 +12892,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12925,7 +12925,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12959,7 +12959,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -12991,7 +12991,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13025,7 +13025,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13064,7 +13064,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13117,7 +13117,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13157,7 +13157,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13196,7 +13196,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13229,7 +13229,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13263,7 +13263,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13295,7 +13295,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13328,7 +13328,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13361,7 +13361,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13391,7 +13391,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13421,7 +13421,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13461,7 +13461,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13495,13 +13495,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapivortexv1CreateOrgResponse"
+              "$ref": "#/definitions/blueapiVortexV1CreateOrgResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13511,7 +13511,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/blueapivortexv1CreateOrgRequest"
+              "$ref": "#/definitions/blueapiVortexV1CreateOrgRequest"
             }
           }
         ],
@@ -13534,7 +13534,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13555,7 +13555,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13582,13 +13582,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapicoverv1ListExchangeRatesResponse"
+              "$ref": "#/definitions/blueapiCoverV1ListExchangeRatesResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13627,7 +13627,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13677,19 +13677,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/gcv1Org"
+                  "$ref": "#/definitions/gcV1Org"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of gcv1Org"
+              "title": "Stream result of gcV1Org"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13722,7 +13722,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13754,7 +13754,7 @@
                   "$ref": "#/definitions/v1Product"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Product"
@@ -13763,7 +13763,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13796,7 +13796,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13829,7 +13829,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13862,7 +13862,7 @@
                   "$ref": "#/definitions/v1Project"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Project"
@@ -13871,7 +13871,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13904,7 +13904,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13935,7 +13935,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -13966,7 +13966,7 @@
                   "$ref": "#/definitions/v1ListProjectToTeamResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListProjectToTeamResponse"
@@ -13975,7 +13975,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14007,7 +14007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14039,7 +14039,7 @@
                   "$ref": "#/definitions/v1Prompt"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Prompt"
@@ -14048,7 +14048,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14080,7 +14080,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14112,7 +14112,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14147,7 +14147,7 @@
                   "$ref": "#/definitions/v1ListRecommendationResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListRecommendationResponse"
@@ -14156,7 +14156,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14189,7 +14189,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14238,7 +14238,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14271,7 +14271,7 @@
                   "$ref": "#/definitions/v1GetExecutionStatusResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetExecutionStatusResponse"
@@ -14280,7 +14280,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14303,7 +14303,7 @@
                   "$ref": "#/definitions/v1ListRecommendationResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListRecommendationResponse"
@@ -14312,7 +14312,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14429,7 +14429,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14462,7 +14462,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14536,7 +14536,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14569,7 +14569,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14612,7 +14612,7 @@
                   "$ref": "#/definitions/v1RecommendationSummary"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1RecommendationSummary"
@@ -14621,7 +14621,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14654,7 +14654,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14675,7 +14675,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14708,7 +14708,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14767,7 +14767,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14799,7 +14799,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14832,7 +14832,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14864,7 +14864,7 @@
                   "$ref": "#/definitions/v1ReportSchedule"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ReportSchedule"
@@ -14873,7 +14873,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14906,7 +14906,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14946,7 +14946,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -14979,7 +14979,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15010,7 +15010,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15051,7 +15051,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15085,7 +15085,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15130,7 +15130,7 @@
                   "$ref": "#/definitions/rippleReseller"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of rippleReseller"
@@ -15139,7 +15139,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15169,7 +15169,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15203,7 +15203,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15241,7 +15241,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15271,7 +15271,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15311,7 +15311,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15389,7 +15389,7 @@
                   "$ref": "#/definitions/v1ResourceAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ResourceAccount"
@@ -15398,7 +15398,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15437,7 +15437,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15500,7 +15500,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15526,13 +15526,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15566,7 +15566,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15600,7 +15600,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15635,7 +15635,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15665,7 +15665,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15703,7 +15703,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15743,7 +15743,7 @@
                   "$ref": "#/definitions/v1AccountInvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AccountInvoiceServiceDiscounts"
@@ -15752,7 +15752,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15793,7 +15793,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15833,7 +15833,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15863,7 +15863,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15893,7 +15893,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15931,7 +15931,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -15965,13 +15965,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16009,7 +16009,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16033,13 +16033,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16079,7 +16079,7 @@
                   "$ref": "#/definitions/v1Service"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Service"
@@ -16088,7 +16088,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16128,7 +16128,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16159,19 +16159,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapibillingv1InvoiceServiceDiscounts"
+                  "$ref": "#/definitions/blueapiBillingV1InvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapibillingv1InvoiceServiceDiscounts"
+              "title": "Stream result of blueapiBillingV1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16205,7 +16205,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16237,7 +16237,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16269,7 +16269,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16301,7 +16301,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16331,7 +16331,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16371,7 +16371,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16405,7 +16405,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16437,7 +16437,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16476,7 +16476,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16509,7 +16509,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16543,7 +16543,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16582,7 +16582,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16612,7 +16612,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16652,7 +16652,7 @@
                   "$ref": "#/definitions/lusterSpace"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of lusterSpace"
@@ -16661,7 +16661,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16692,19 +16692,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/billingv1TagData"
+                  "$ref": "#/definitions/billingV1TagData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of billingv1TagData"
+              "title": "Stream result of billingV1TagData"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16741,7 +16741,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16773,7 +16773,7 @@
                   "$ref": "#/definitions/v1Team"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Team"
@@ -16782,7 +16782,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16814,7 +16814,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16844,7 +16844,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16870,13 +16870,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiprismv1TestResponse"
+              "$ref": "#/definitions/blueapiPrismV1TestResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16893,13 +16893,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapivortexv1TestResponse"
+              "$ref": "#/definitions/blueapiVortexV1TestResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16930,7 +16930,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16951,7 +16951,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -16984,7 +16984,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17007,7 +17007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17040,7 +17040,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17073,7 +17073,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17106,7 +17106,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17150,7 +17150,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17183,7 +17183,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17243,7 +17243,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17276,7 +17276,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17309,7 +17309,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17339,7 +17339,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17369,7 +17369,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17409,7 +17409,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17430,7 +17430,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17463,7 +17463,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17493,7 +17493,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17523,7 +17523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17563,7 +17563,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17593,7 +17593,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17623,7 +17623,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17663,7 +17663,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17697,7 +17697,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17727,7 +17727,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17760,13 +17760,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapivortexv1GetUserResponse"
+              "$ref": "#/definitions/blueapiVortexV1GetUserResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17797,7 +17797,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17820,7 +17820,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17847,13 +17847,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapicoverv1GetUserResponse"
+              "$ref": "#/definitions/blueapiCoverV1GetUserResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17882,7 +17882,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17913,7 +17913,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17952,7 +17952,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -17990,7 +17990,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18023,7 +18023,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18044,7 +18044,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18077,7 +18077,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18110,7 +18110,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18143,7 +18143,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18166,7 +18166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18206,7 +18206,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18253,7 +18253,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18286,7 +18286,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18316,7 +18316,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18346,7 +18346,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18386,7 +18386,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18425,7 +18425,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18464,7 +18464,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18504,7 +18504,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18544,7 +18544,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18583,7 +18583,7 @@
                   "$ref": "#/definitions/v1Workflow"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1Workflow"
@@ -18592,7 +18592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18625,7 +18625,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18665,7 +18665,7 @@
                   "$ref": "#/definitions/v1ProxyCreateCompletionResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ProxyCreateCompletionResponse"
@@ -18674,7 +18674,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18708,7 +18708,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18738,7 +18738,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18779,7 +18779,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18816,19 +18816,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiapiAccount"
+                  "$ref": "#/definitions/blueapiApiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapiapiAccount"
+              "title": "Stream result of blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18866,13 +18866,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiAccount"
+              "$ref": "#/definitions/blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18912,7 +18912,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -18949,19 +18949,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiapiAccount"
+                  "$ref": "#/definitions/blueapiApiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapiapiAccount"
+              "title": "Stream result of blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19007,7 +19007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19039,13 +19039,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiAccount"
+              "$ref": "#/definitions/blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19090,7 +19090,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19121,13 +19121,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiAccount"
+              "$ref": "#/definitions/blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19174,7 +19174,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19214,7 +19214,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19262,7 +19262,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19310,7 +19310,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19358,7 +19358,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19406,7 +19406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19446,7 +19446,7 @@
                   "$ref": "#/definitions/v1AdjustmentEntry"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1AdjustmentEntry"
@@ -19455,7 +19455,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19496,7 +19496,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19534,19 +19534,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapicostv1CostItem"
+                  "$ref": "#/definitions/blueapiCostV1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapicostv1CostItem"
+              "title": "Stream result of blueapiCostV1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19580,13 +19580,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiwaveBudgetAlert"
+              "$ref": "#/definitions/apiWaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19624,7 +19624,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19655,13 +19655,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiwaveBudgetAlert"
+              "$ref": "#/definitions/apiWaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19700,13 +19700,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiwaveBudgetAlert"
+              "$ref": "#/definitions/apiWaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19753,7 +19753,7 @@
                   "$ref": "#/definitions/apiAccountOriginalResource"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of apiAccountOriginalResource"
@@ -19762,7 +19762,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19802,7 +19802,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19855,7 +19855,7 @@
                   "$ref": "#/definitions/v1GetChildBillingGroupCustomizedBillingServiceResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetChildBillingGroupCustomizedBillingServiceResponse"
@@ -19864,7 +19864,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19902,7 +19902,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19950,7 +19950,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -19988,7 +19988,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20035,7 +20035,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20086,7 +20086,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20140,7 +20140,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20179,7 +20179,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20225,7 +20225,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20255,7 +20255,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20296,7 +20296,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20335,7 +20335,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20367,7 +20367,7 @@
                   "$ref": "#/definitions/v1CalculatorCostModifier"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1CalculatorCostModifier"
@@ -20376,7 +20376,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20407,7 +20407,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20448,7 +20448,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20488,7 +20488,7 @@
                   "$ref": "#/definitions/v1ListCalculatorRunningAccountsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ListCalculatorRunningAccountsResponse"
@@ -20497,7 +20497,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20537,7 +20537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20598,7 +20598,7 @@
                   "$ref": "#/definitions/v1CostAttributeItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1CostAttributeItem"
@@ -20607,7 +20607,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20647,7 +20647,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20678,7 +20678,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20719,7 +20719,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20756,7 +20756,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20803,7 +20803,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20851,7 +20851,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20889,19 +20889,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapicostv1CostItem"
+                  "$ref": "#/definitions/blueapiCostV1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapicostv1CostItem"
+              "title": "Stream result of blueapiCostV1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20941,7 +20941,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -20988,7 +20988,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21035,7 +21035,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21077,13 +21077,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapibillingv1ListExchangeRatesResponse"
+              "$ref": "#/definitions/blueapiBillingV1ListExchangeRatesResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21108,6 +21108,46 @@
         ]
       }
     },
+    "/v1/{vendor}/export/reports:queue": {
+      "post": {
+        "summary": "Queues a vendor report export and delivers results via email notification channel.\nSupports multiple report types per vendor. For AWS, this covers RI/SP utilization reports.",
+        "operationId": "Cost_ExportReport",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ExportReportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "vendor",
+            "description": "Optional. Cloud vendor.\nAccepted values: \"aws\", \"gcp\", \"azure\".\nIf empty, defaults to \"aws\" for backward compatibility.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CostExportReportBody"
+            }
+          }
+        ],
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
     "/v1/{vendor}/forecasts": {
       "get": {
         "summary": "Fetches cost forecasts for the specified billing group. Includes historical cost (up to previous month) and forecasted cost (up to three months for now).",
@@ -21122,7 +21162,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21189,7 +21229,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21242,7 +21282,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21295,7 +21335,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21355,7 +21395,7 @@
                   "$ref": "#/definitions/waveAdjustment"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of waveAdjustment"
@@ -21364,7 +21404,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21404,7 +21444,7 @@
                   "$ref": "#/definitions/v1ReadInvoiceIdsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1ReadInvoiceIdsResponse"
@@ -21413,7 +21453,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21451,19 +21491,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapicostv1CostItem"
+                  "$ref": "#/definitions/blueapiCostV1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapicostv1CostItem"
+              "title": "Stream result of blueapiCostV1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21501,19 +21541,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiapiAccount"
+                  "$ref": "#/definitions/blueapiApiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapiapiAccount"
+              "title": "Stream result of blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21544,13 +21584,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiapiAccount"
+              "$ref": "#/definitions/blueapiApiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21591,7 +21631,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21632,7 +21672,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21680,7 +21720,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21718,7 +21758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21758,7 +21798,7 @@
                   "$ref": "#/definitions/v1GetPayerAccountImportHistoryResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1GetPayerAccountImportHistoryResponse"
@@ -21767,7 +21807,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21813,7 +21853,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21853,7 +21893,7 @@
                   "$ref": "#/definitions/v1PayerAccountExtended"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1PayerAccountExtended"
@@ -21862,7 +21902,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21902,7 +21942,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21941,7 +21981,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -21988,7 +22028,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22035,7 +22075,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22073,7 +22113,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22113,7 +22153,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22153,7 +22193,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22189,19 +22229,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapicostv1CostItem"
+                  "$ref": "#/definitions/blueapiCostV1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
-              "title": "Stream result of blueapicostv1CostItem"
+              "title": "Stream result of blueapiCostV1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22241,7 +22281,7 @@
                   "$ref": "#/definitions/apiCostTag"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of apiCostTag"
@@ -22250,7 +22290,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22296,7 +22336,7 @@
                   "$ref": "#/definitions/apiCostTag"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of apiCostTag"
@@ -22305,7 +22345,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22351,7 +22391,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22388,7 +22428,7 @@
                   "$ref": "#/definitions/v1TagsAddingSetting"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1TagsAddingSetting"
@@ -22397,7 +22437,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22432,7 +22472,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22477,7 +22517,7 @@
                   "$ref": "#/definitions/rippleUntaggedGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of rippleUntaggedGroup"
@@ -22486,7 +22526,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22526,7 +22566,7 @@
                   "$ref": "#/definitions/v1UsageCostsDrift"
                 },
                 "error": {
-                  "$ref": "#/definitions/googlerpcStatus"
+                  "$ref": "#/definitions/googleRpcStatus"
                 }
               },
               "title": "Stream result of v1UsageCostsDrift"
@@ -22535,7 +22575,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22575,7 +22615,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/googleRpcStatus"
             }
           }
         },
@@ -22914,7 +22954,7 @@
           "description": "Required\nValid values:\n`InvoiceCalculationStarted`,\n`InvoiceCalculationFinished`,\n`CurUpdatedAfterInvoice`.\n`AccountBudgetAlert`."
         },
         "account": {
-          "$ref": "#/definitions/adminv1NotificationAccount",
+          "$ref": "#/definitions/adminV1NotificationAccount",
           "description": "Optional. only available Wave(Pro)."
         }
       },
@@ -23005,6 +23045,18 @@
         "AWS_ONBOARDING_FEATURE_STATUS_UNKNOWN"
       ],
       "default": "AWS_ONBOARDING_FEATURE_STATUS_UNSPECIFIED"
+    },
+    "AwsRispExportOptionsColumns": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Per-report column filter container."
     },
     "BillingAllocateAdjustmentEntryBody": {
       "type": "object",
@@ -23151,7 +23203,7 @@
           "description": "Optional. groups to apply the invoices setting\nthis is ignored if allGroups is true."
         },
         "invoiceSetting": {
-          "$ref": "#/definitions/billingv1InvoiceSettings",
+          "$ref": "#/definitions/billingV1InvoiceSettings",
           "description": "Required. Invoice setting."
         }
       }
@@ -23310,7 +23362,7 @@
           "description": "Optional. groups to apply the invoices setting\nthis is ignored if allGroups is true."
         },
         "invoiceSetting": {
-          "$ref": "#/definitions/billingv1InvoiceSettings",
+          "$ref": "#/definitions/billingV1InvoiceSettings",
           "description": "Required. Invoice setting."
         }
       }
@@ -23793,7 +23845,7 @@
       "type": "object",
       "properties": {
         "invoiceServiceDiscounts": {
-          "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts",
+          "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts",
           "description": "Required. The updated invoice service discounts object."
         },
         "updateMask": {
@@ -24105,7 +24157,7 @@
       "type": "object",
       "properties": {
         "budgetAlert": {
-          "$ref": "#/definitions/apiwaveBudgetAlert",
+          "$ref": "#/definitions/apiWaveBudgetAlert",
           "description": "Required. Budget alert setting."
         }
       },
@@ -24115,7 +24167,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiapiBudget"
+          "$ref": "#/definitions/blueapiApiBudget"
         }
       },
       "title": "Request message for CreateAccountBudget"
@@ -24292,6 +24344,27 @@
         }
       },
       "description": "Request message for the ExportCostFiltersFile rpc."
+    },
+    "CostExportReportBody": {
+      "type": "object",
+      "properties": {
+        "month": {
+          "type": "string",
+          "description": "Required. Billing month in YYYY-MM format."
+        },
+        "notificationChannelIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Notification channel IDs to deliver the report.\nIf empty, the MSP default notification channel configured in DynamoDB is used."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1AwsRispExportOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS RI/SP export options.\n\nFuture vendor-specific options follow the same pattern (e.g. gcp_options, azure_options)."
+        }
+      },
+      "description": "Request message for ExportReport."
     },
     "CostGetCostReductionBody": {
       "type": "object",
@@ -24686,7 +24759,7 @@
       "type": "object",
       "properties": {
         "budgetAlert": {
-          "$ref": "#/definitions/apiwaveBudgetAlert",
+          "$ref": "#/definitions/apiWaveBudgetAlert",
           "description": "Required. Budget alert setting.\n\nSet only the setting value to be changed.\nFor example, If you want to change only daily value, set `{\"budget\":[{\"id\":\"daily\",\"value\":100,\"enabled\":true}}` as a parameter\nThe same goes for notification. If you want to change only email value, set `{\"notification\":[{\"id\":\"email\",\"destination\":\"budgetalert-example@alphaus.cloud\",\"enabled\":true}}` as a parameter"
         }
       },
@@ -24696,7 +24769,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiapiBudget"
+          "$ref": "#/definitions/blueapiApiBudget"
         }
       },
       "title": "Request message for UpdateAccountBudget"
@@ -25110,7 +25183,7 @@
           "title": "Optional. Description of the forecast"
         },
         "costGroup": {
-          "$ref": "#/definitions/apicoverCostGroup",
+          "$ref": "#/definitions/apiCoverCostGroup",
           "title": "Optional. Cost Group Id and Name"
         },
         "pastActualCostRange": {
@@ -25204,11 +25277,11 @@
           "title": "GCP Options"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apicoverAzureOptions",
+          "$ref": "#/definitions/apiCoverAzureOptions",
           "title": "Azure Options"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apicoverAwsOptions",
+          "$ref": "#/definitions/apiCoverAwsOptions",
           "title": "AWS Options"
         },
         "accountType": {
@@ -27606,7 +27679,7 @@
         }
       }
     },
-    "adminv1NotificationAccount": {
+    "adminV1NotificationAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -27650,7 +27723,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiFeeDetails"
+            "$ref": "#/definitions/blueapiApiFeeDetails"
           },
           "title": "feeDetails: Includes details of re-caluclated fee data"
         },
@@ -27689,7 +27762,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           }
         }
       }
@@ -27848,6 +27921,374 @@
       },
       "description": "AuditExportData resource definition."
     },
+    "apiAwsChartData": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "actualOndemand": {
+          "type": "number",
+          "format": "double"
+        },
+        "actualCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "utilization": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "apiAwsCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "The account being queried."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "type": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "productCode": {
+          "type": "string",
+          "description": "The product code for an AWS service, such as `AmazonEC2`, `AmazonRDS`, etc. This can also be an Alphaus-specified custom value."
+        },
+        "serviceCode": {
+          "type": "string",
+          "description": "The CUR service code of the lineitem, if applicable. Sometimes, this is the same as `productCode`, a subset of `productCode`, an Alphaus-specified custom value, or empty."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of the lineitem, if applicable."
+        },
+        "zone": {
+          "type": "string",
+          "description": "The zone of the lineitem, if applicable."
+        },
+        "usageType": {
+          "type": "string",
+          "description": "The CUR usage type of the lineitem, if applicable."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The CUR instance type of the lineitem, if applicable."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The CUR operation of the lineitem, if applicable."
+        },
+        "invoiceId": {
+          "type": "string",
+          "description": "The AWS invoice ID of the lineitem, if applicable."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the lineitem, if applicable."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The resource id of the lineitem, if applicable. At the moment, this is not yet fully supported."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "usage": {
+          "type": "number",
+          "format": "double",
+          "description": "Only set when `description` and/or `resourceId` attributes are specified."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The true cost (calculated) for this lineitem."
+        },
+        "unblendedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "The unblended cost as reflected in the CUR for this lineitem."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The base currency for `cost`, `unblendedCost`, `effectiveCost`, `amortizedCost`. Always set to `USD`, CUR's default currency."
+        },
+        "exchangeRate": {
+          "type": "number",
+          "format": "double",
+          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
+        },
+        "targetCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `cost`."
+        },
+        "targetUnblendedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `unblendedCost`."
+        },
+        "targetCurrency": {
+          "type": "string",
+          "description": "The currency set by `toCurrency`."
+        },
+        "effectiveCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "targetEffectiveCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `effectiveCost`."
+        },
+        "amortizedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "targetAmortizedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `amortizedCost`."
+        },
+        "tagId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Get last update in UNIX time format."
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiKeyValue"
+          },
+          "description": "Various metadata associated with this lineitem."
+        }
+      }
+    },
+    "apiAwsCostAttribute": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "serviceCode": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "zone": {
+          "type": "string"
+        },
+        "usageType": {
+          "type": "string"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "invoiceId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiAzureCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "The account being queried."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "serviceName": {
+          "type": "string",
+          "description": "The service name, such as `Software License`, `Cognosys`, `SendGrid`, `New-Commerce ERP Software License`, etc."
+        },
+        "productName": {
+          "type": "string",
+          "description": "The product code for an Azure service, such as `Dsv4 Series Windows VM`, `CentOS 7.6`, etc."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of lineitem, if applicable."
+        },
+        "chargeType": {
+          "type": "string",
+          "description": "The charge type of lineitem, if applicable. Such as `New`, `CycleCharge`, `Prorate fees when cancel`, etc."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of lineitem, if applicable."
+        },
+        "billableQuantity": {
+          "type": "number",
+          "format": "double",
+          "description": "The billable quantity of lineitem, if applicable."
+        },
+        "effectiveUnitPrice": {
+          "type": "number",
+          "format": "double",
+          "description": "The effective unit price of lineitem, if applicable."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The true cost (calculated) for this lineitem."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The base currency for `cost`."
+        },
+        "exchangeRate": {
+          "type": "number",
+          "format": "double",
+          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
+        },
+        "targetCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `cost`."
+        },
+        "targetCurrency": {
+          "type": "string",
+          "description": "The currency set by `toCurrency`."
+        },
+        "timeInterval": {
+          "type": "string",
+          "description": "The time interval of lineitem, if applicable. Format is `yyyy-MM-ddThh:MM:ssZ/yyyy-mm-ddTHH:mm:ssZ` (for example 2020-09-16T00:00:00Z/2021-09-24T00:00:00Z)."
+        },
+        "billingType": {
+          "type": "string",
+          "description": "The billing type of lineitem, if applicable. Such as `MARKETPLACE`, `UPFRONT`, `Refund`, `Credit` and `OTHERS`."
+        },
+        "alternateId": {
+          "type": "string",
+          "description": "The alternate ID of lineitem, if applicable."
+        },
+        "domainName": {
+          "type": "string",
+          "description": "The domain name of lineitem, if applicable."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation of lineitem, if applicable. Such as `Cool LRS Write Operations`, `Cool LRS Data Write`, `Standard Data Transfer Out`, etc."
+        },
+        "usageType": {
+          "type": "string",
+          "description": "The usage type of lineitem, if applicable. Such as `Standard HDD Managed Disks`, `Tables`, `Blob Storage`, etc."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The instance type of lineitem, if applicable. Such as `Gateway`, `Standard_B2s`, `Standard_D4s_v3`, etc."
+        },
+        "category": {
+          "type": "string",
+          "description": "The category of lineitem, if applicable. Such as `Software License`, `Marketplace`, `RI`, `Other`, etc."
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "The subscription id."
+        },
+        "entitlementId": {
+          "type": "string",
+          "description": "The entitlement id."
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "The resource group of the lineitem, if applicable."
+        }
+      }
+    },
+    "apiAzureCostAttribute": {
+      "type": "object",
+      "properties": {
+        "customerId": {
+          "type": "string"
+        },
+        "subscriptionId": {
+          "type": "string"
+        },
+        "entitlementId": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "productId": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "skuId": {
+          "type": "string"
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "domainName": {
+          "type": "string"
+        }
+      }
+    },
     "apiBillingGroupForecast": {
       "type": "object",
       "properties": {
@@ -27944,6 +28385,476 @@
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the costtag."
+        }
+      }
+    },
+    "apiCoverAWSRecommendations": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "string"
+        },
+        "instanceName": {
+          "type": "string"
+        },
+        "service": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "costGroup": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "estsavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "estcost": {
+          "type": "number",
+          "format": "double"
+        },
+        "estsavingsPercentage": {
+          "type": "number",
+          "format": "double"
+        },
+        "resourceArn": {
+          "type": "string"
+        },
+        "restartNeeded": {
+          "type": "boolean"
+        },
+        "rollbackPossible": {
+          "type": "boolean"
+        },
+        "lastUpdatedAt": {
+          "type": "string"
+        },
+        "recommendationGroup": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "purchaseRIRecommendationDetails": {
+          "$ref": "#/definitions/coverPurchaseRIRecommendationDetails"
+        },
+        "savingsPlanRecommendationDetails": {
+          "$ref": "#/definitions/coverSavingsPlanRecommendationDetails"
+        },
+        "rightSizingRecommendationDetails": {
+          "$ref": "#/definitions/coverRightSizingRecommendationDetails"
+        },
+        "upgradeRecommendationDetails": {
+          "$ref": "#/definitions/coverUpgradeRecommendationDetails"
+        },
+        "migrateRecommendationDetails": {
+          "$ref": "#/definitions/coverMigrateRecommendationDetails"
+        },
+        "stopInstanceRecommendationDetails": {
+          "$ref": "#/definitions/coverStopInstanceRecommendationDetails"
+        },
+        "deleteRecommendationDetails": {
+          "$ref": "#/definitions/coverDeleteRecommendationDetails"
+        },
+        "otherRecommendationDetails": {
+          "$ref": "#/definitions/coverOtherRecommendationDetails"
+        }
+      }
+    },
+    "apiCoverAccount": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "title": "account, subscription, project"
+        }
+      }
+    },
+    "apiCoverAwsOptions": {
+      "type": "object",
+      "properties": {
+        "AccountName": {
+          "type": "string"
+        },
+        "PayerId": {
+          "type": "string"
+        },
+        "RoleArn": {
+          "type": "string"
+        },
+        "ExternalId": {
+          "type": "string"
+        },
+        "StackId": {
+          "type": "string"
+        },
+        "StackRegion": {
+          "type": "string"
+        },
+        "TemplateUrl": {
+          "type": "string"
+        },
+        "BucketName": {
+          "type": "string"
+        },
+        "Prefix": {
+          "type": "string"
+        },
+        "ReportName": {
+          "type": "string"
+        },
+        "registrationStatus": {
+          "$ref": "#/definitions/coverRegistrationStatus"
+        },
+        "Status": {
+          "type": "string"
+        },
+        "RegistrationMethod": {
+          "type": "string",
+          "title": "Valid values for now are: 'console', 'terraform'. default would be 'console'"
+        },
+        "templateVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverAzureOptions": {
+      "type": "object",
+      "properties": {
+        "accountName": {
+          "type": "string"
+        },
+        "azureCustomerId": {
+          "type": "string"
+        },
+        "azurePlanId": {
+          "type": "string"
+        },
+        "serviceAcct": {
+          "type": "string"
+        },
+        "partnerAcct": {
+          "type": "string"
+        },
+        "companyId": {
+          "type": "string"
+        },
+        "payerId": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverBudgetAlert": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverThreshold"
+          }
+        },
+        "channels": {
+          "$ref": "#/definitions/coverAlertChannels"
+        }
+      }
+    },
+    "apiCoverCategory": {
+      "type": "object",
+      "properties": {
+        "display": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverCostCalculation": {
+      "type": "object",
+      "properties": {
+        "estCostAfterDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "estCostBeforeDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "otherDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "savingsPlanDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "estNetUnusedAmortizedCommitments": {
+          "type": "number",
+          "format": "double"
+        },
+        "reservedInstanceDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "usageTypes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiCoverUsageTypes"
+          }
+        }
+      }
+    },
+    "apiCoverCostGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "title": "cost group name"
+        }
+      }
+    },
+    "apiCoverEBSDetails": {
+      "type": "object",
+      "properties": {
+        "currentEBSDetails": {
+          "$ref": "#/definitions/coverCurrentEBSDetails"
+        },
+        "upgradeEBSDetails": {
+          "$ref": "#/definitions/coverEBSRecommendationDetails"
+        }
+      }
+    },
+    "apiCoverEC2Details": {
+      "type": "object",
+      "properties": {
+        "instanceType": {
+          "type": "string"
+        },
+        "tenancy": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverMemoryDBDetails": {
+      "type": "object",
+      "properties": {
+        "family": {
+          "type": "string"
+        },
+        "nodeType": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverRDSDetails": {
+      "type": "object",
+      "properties": {
+        "dbEdition": {
+          "type": "string"
+        },
+        "dbEngine": {
+          "type": "string"
+        },
+        "deploymentOptions": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "licenseModel": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverRecommendationDetail": {
+      "type": "object",
+      "properties": {
+        "recommendation": {
+          "type": "string"
+        },
+        "recommendedResourceType": {
+          "type": "string"
+        },
+        "estimatedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "estimatedSavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "region": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverRedshiftDetails": {
+      "type": "object",
+      "properties": {
+        "currentGeneration": {
+          "type": "boolean"
+        },
+        "nodeType": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverResult": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverRole": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "costgroupsIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiCoverTagData": {
+      "type": "object",
+      "properties": {
+        "tagKey": {
+          "type": "string"
+        },
+        "tagValue": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiCoverUsageTypes": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "usageAmount": {
+          "type": "number",
+          "format": "double"
+        },
+        "usageType": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverUser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverUserRole"
+          }
+        },
+        "invitedBy": {
+          "type": "object"
+        },
+        "lastUpdated": {
+          "type": "string"
+        },
+        "createdOn": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        },
+        "activated": {
+          "type": "boolean"
+        },
+        "colorTheme": {
+          "type": "string"
+        }
+      }
+    },
+    "apiCoverUtilizationData": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "format": "float"
         }
       }
     },
@@ -28232,6 +29143,71 @@
         }
       }
     },
+    "apiGcpCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "title": "account data"
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "invoiceMonth": {
+          "type": "string",
+          "description": "The invoice.month of the lineitem, if applicable."
+        },
+        "service": {
+          "type": "string",
+          "description": "The service.Description of the lineitem, if applicable."
+        },
+        "sku": {
+          "type": "string",
+          "description": "The sku.Description of the lineitem, if applicable."
+        },
+        "region": {
+          "type": "string",
+          "description": "The location.region of the lineitem, if applicable."
+        },
+        "zone": {
+          "type": "string",
+          "description": "The location.zone of the lineitem, if applicable."
+        },
+        "creditsType": {
+          "type": "string",
+          "description": "The credits.type of the lineitem, if applicable."
+        },
+        "creditsName": {
+          "type": "string",
+          "description": "The credits.name of the lineitem, if applicable."
+        },
+        "usageUnit": {
+          "type": "string",
+          "description": "The usage.pricing_unit of the lineitem, if applicable."
+        },
+        "usageAmount": {
+          "type": "number",
+          "format": "double",
+          "description": "The usage.amount_in_pricing_units of the lineitem, if applicable."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The currency of the lineitem, if applicable."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The cost of the lineitem, if applicable."
+        }
+      },
+      "description": "see gcp billing data schema details:[https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables]",
+      "title": "Cost for Api Response"
+    },
     "apiGroupCustomDetails": {
       "type": "object",
       "properties": {
@@ -28403,6 +29379,38 @@
         }
       },
       "description": "KeyValueMap resource definition."
+    },
+    "apiLusterLabel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The label id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The label name."
+        },
+        "color": {
+          "type": "string",
+          "description": "The label color.\nformat: HEX color code ( #FF0000 )."
+        },
+        "description": {
+          "type": "string",
+          "description": "The label description."
+        },
+        "createdAt": {
+          "type": "string",
+          "title": "The label createdAt.\n\"created_at\": \"2023-10-27T10:00:00Z\"",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "title": "The label updatedAt.\n\"updated_at\": \"2023-10-27T10:00:00Z\"",
+          "readOnly": true
+        }
+      },
+      "title": "The message defines the label"
     },
     "apiMSTeamsChannel": {
       "type": "object",
@@ -28694,6 +29702,80 @@
         }
       }
     },
+    "apiRippleAccessGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "billingGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "AccessGroup resource definition."
+    },
+    "apiRippleOrg": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The unique name (or id) of the organization."
+        },
+        "email": {
+          "type": "string",
+          "description": "The registered email of the organization."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The metadata (key/value pair) of the organization. If hierarchy is supported, it will be\nseparated by '/', such as 'metakey/subkey=value'. See https://alphauslabs.github.io/blueapi/\nfor the list of supported attributes."
+        }
+      },
+      "description": "Org resource definition."
+    },
+    "apiRippleV1InvoiceServiceDiscounts": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The invoice service discounts id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The invoice service discount name.\nmust be 1-60 characters long."
+        },
+        "description": {
+          "type": "string",
+          "description": "The invoice service discount description.\nMaximum 150 characters long."
+        },
+        "setting": {
+          "$ref": "#/definitions/v1InvoiceServiceDiscountsSetting",
+          "description": "The invoice service discount setting."
+        },
+        "created": {
+          "type": "string",
+          "description": "Timestamp associated with the created.",
+          "readOnly": true
+        },
+        "updated": {
+          "type": "string",
+          "description": "Timestamp associated with the updated.",
+          "readOnly": true
+        }
+      },
+      "description": "InvoiceServiceDiscounts resource definition."
+    },
     "apiSlackChannel": {
       "type": "object",
       "properties": {
@@ -28837,1022 +29919,13 @@
           "title": "total: Includes data on billing totals"
         },
         "settings": {
-          "$ref": "#/definitions/blueapiapiInvoiceSettings",
+          "$ref": "#/definitions/blueapiApiInvoiceSettings",
           "title": "settings: Includes settings related to billing"
         }
       },
       "description": "VendorDetail resource definition."
     },
-    "apiawsChartData": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string"
-        },
-        "actualOndemand": {
-          "type": "number",
-          "format": "double"
-        },
-        "actualCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "utilization": {
-          "type": "number",
-          "format": "double"
-        }
-      }
-    },
-    "apiawsCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "description": "The account being queried."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "type": {
-          "type": "string"
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "productCode": {
-          "type": "string",
-          "description": "The product code for an AWS service, such as `AmazonEC2`, `AmazonRDS`, etc. This can also be an Alphaus-specified custom value."
-        },
-        "serviceCode": {
-          "type": "string",
-          "description": "The CUR service code of the lineitem, if applicable. Sometimes, this is the same as `productCode`, a subset of `productCode`, an Alphaus-specified custom value, or empty."
-        },
-        "region": {
-          "type": "string",
-          "description": "The region of the lineitem, if applicable."
-        },
-        "zone": {
-          "type": "string",
-          "description": "The zone of the lineitem, if applicable."
-        },
-        "usageType": {
-          "type": "string",
-          "description": "The CUR usage type of the lineitem, if applicable."
-        },
-        "instanceType": {
-          "type": "string",
-          "description": "The CUR instance type of the lineitem, if applicable."
-        },
-        "operation": {
-          "type": "string",
-          "description": "The CUR operation of the lineitem, if applicable."
-        },
-        "invoiceId": {
-          "type": "string",
-          "description": "The AWS invoice ID of the lineitem, if applicable."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the lineitem, if applicable."
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "The resource id of the lineitem, if applicable. At the moment, this is not yet fully supported."
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "costCategories": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "usage": {
-          "type": "number",
-          "format": "double",
-          "description": "Only set when `description` and/or `resourceId` attributes are specified."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The true cost (calculated) for this lineitem."
-        },
-        "unblendedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "The unblended cost as reflected in the CUR for this lineitem."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The base currency for `cost`, `unblendedCost`, `effectiveCost`, `amortizedCost`. Always set to `USD`, CUR's default currency."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
-        },
-        "targetCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `cost`."
-        },
-        "targetUnblendedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `unblendedCost`."
-        },
-        "targetCurrency": {
-          "type": "string",
-          "description": "The currency set by `toCurrency`."
-        },
-        "effectiveCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "targetEffectiveCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `effectiveCost`."
-        },
-        "amortizedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "targetAmortizedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `amortizedCost`."
-        },
-        "tagId": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "string",
-          "description": "Get last update in UNIX time format."
-        },
-        "metadata": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiKeyValue"
-          },
-          "description": "Various metadata associated with this lineitem."
-        }
-      }
-    },
-    "apiawsCostAttribute": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string"
-        },
-        "groupId": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "serviceCode": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "zone": {
-          "type": "string"
-        },
-        "usageType": {
-          "type": "string"
-        },
-        "instanceType": {
-          "type": "string"
-        },
-        "operation": {
-          "type": "string"
-        },
-        "invoiceId": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "resourceId": {
-          "type": "string"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "costCategories": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiazureCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "description": "The account being queried."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "serviceName": {
-          "type": "string",
-          "description": "The service name, such as `Software License`, `Cognosys`, `SendGrid`, `New-Commerce ERP Software License`, etc."
-        },
-        "productName": {
-          "type": "string",
-          "description": "The product code for an Azure service, such as `Dsv4 Series Windows VM`, `CentOS 7.6`, etc."
-        },
-        "region": {
-          "type": "string",
-          "description": "The region of lineitem, if applicable."
-        },
-        "chargeType": {
-          "type": "string",
-          "description": "The charge type of lineitem, if applicable. Such as `New`, `CycleCharge`, `Prorate fees when cancel`, etc."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of lineitem, if applicable."
-        },
-        "billableQuantity": {
-          "type": "number",
-          "format": "double",
-          "description": "The billable quantity of lineitem, if applicable."
-        },
-        "effectiveUnitPrice": {
-          "type": "number",
-          "format": "double",
-          "description": "The effective unit price of lineitem, if applicable."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The true cost (calculated) for this lineitem."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The base currency for `cost`."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
-        },
-        "targetCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `cost`."
-        },
-        "targetCurrency": {
-          "type": "string",
-          "description": "The currency set by `toCurrency`."
-        },
-        "timeInterval": {
-          "type": "string",
-          "description": "The time interval of lineitem, if applicable. Format is `yyyy-MM-ddThh:MM:ssZ/yyyy-mm-ddTHH:mm:ssZ` (for example 2020-09-16T00:00:00Z/2021-09-24T00:00:00Z)."
-        },
-        "billingType": {
-          "type": "string",
-          "description": "The billing type of lineitem, if applicable. Such as `MARKETPLACE`, `UPFRONT`, `Refund`, `Credit` and `OTHERS`."
-        },
-        "alternateId": {
-          "type": "string",
-          "description": "The alternate ID of lineitem, if applicable."
-        },
-        "domainName": {
-          "type": "string",
-          "description": "The domain name of lineitem, if applicable."
-        },
-        "operation": {
-          "type": "string",
-          "description": "The operation of lineitem, if applicable. Such as `Cool LRS Write Operations`, `Cool LRS Data Write`, `Standard Data Transfer Out`, etc."
-        },
-        "usageType": {
-          "type": "string",
-          "description": "The usage type of lineitem, if applicable. Such as `Standard HDD Managed Disks`, `Tables`, `Blob Storage`, etc."
-        },
-        "instanceType": {
-          "type": "string",
-          "description": "The instance type of lineitem, if applicable. Such as `Gateway`, `Standard_B2s`, `Standard_D4s_v3`, etc."
-        },
-        "category": {
-          "type": "string",
-          "description": "The category of lineitem, if applicable. Such as `Software License`, `Marketplace`, `RI`, `Other`, etc."
-        },
-        "subscriptionId": {
-          "type": "string",
-          "description": "The subscription id."
-        },
-        "entitlementId": {
-          "type": "string",
-          "description": "The entitlement id."
-        },
-        "resourceGroup": {
-          "type": "string",
-          "description": "The resource group of the lineitem, if applicable."
-        }
-      }
-    },
-    "apiazureCostAttribute": {
-      "type": "object",
-      "properties": {
-        "customerId": {
-          "type": "string"
-        },
-        "subscriptionId": {
-          "type": "string"
-        },
-        "entitlementId": {
-          "type": "string"
-        },
-        "groupId": {
-          "type": "string"
-        },
-        "productId": {
-          "type": "string"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "skuId": {
-          "type": "string"
-        },
-        "skuName": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "domainName": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverAWSRecommendations": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "accountId": {
-          "type": "string"
-        },
-        "accountName": {
-          "type": "string"
-        },
-        "instanceId": {
-          "type": "string"
-        },
-        "instanceName": {
-          "type": "string"
-        },
-        "service": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string"
-        },
-        "costGroup": {
-          "type": "string"
-        },
-        "recommendation": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "estsavings": {
-          "type": "number",
-          "format": "double"
-        },
-        "estcost": {
-          "type": "number",
-          "format": "double"
-        },
-        "estsavingsPercentage": {
-          "type": "number",
-          "format": "double"
-        },
-        "resourceArn": {
-          "type": "string"
-        },
-        "restartNeeded": {
-          "type": "boolean"
-        },
-        "rollbackPossible": {
-          "type": "boolean"
-        },
-        "lastUpdatedAt": {
-          "type": "string"
-        },
-        "recommendationGroup": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "purchaseRIRecommendationDetails": {
-          "$ref": "#/definitions/coverPurchaseRIRecommendationDetails"
-        },
-        "savingsPlanRecommendationDetails": {
-          "$ref": "#/definitions/coverSavingsPlanRecommendationDetails"
-        },
-        "rightSizingRecommendationDetails": {
-          "$ref": "#/definitions/coverRightSizingRecommendationDetails"
-        },
-        "upgradeRecommendationDetails": {
-          "$ref": "#/definitions/coverUpgradeRecommendationDetails"
-        },
-        "migrateRecommendationDetails": {
-          "$ref": "#/definitions/coverMigrateRecommendationDetails"
-        },
-        "stopInstanceRecommendationDetails": {
-          "$ref": "#/definitions/coverStopInstanceRecommendationDetails"
-        },
-        "deleteRecommendationDetails": {
-          "$ref": "#/definitions/coverDeleteRecommendationDetails"
-        },
-        "otherRecommendationDetails": {
-          "$ref": "#/definitions/coverOtherRecommendationDetails"
-        }
-      }
-    },
-    "apicoverAccount": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "title": "account, subscription, project"
-        }
-      }
-    },
-    "apicoverAwsOptions": {
-      "type": "object",
-      "properties": {
-        "AccountName": {
-          "type": "string"
-        },
-        "PayerId": {
-          "type": "string"
-        },
-        "RoleArn": {
-          "type": "string"
-        },
-        "ExternalId": {
-          "type": "string"
-        },
-        "StackId": {
-          "type": "string"
-        },
-        "StackRegion": {
-          "type": "string"
-        },
-        "TemplateUrl": {
-          "type": "string"
-        },
-        "BucketName": {
-          "type": "string"
-        },
-        "Prefix": {
-          "type": "string"
-        },
-        "ReportName": {
-          "type": "string"
-        },
-        "registrationStatus": {
-          "$ref": "#/definitions/coverRegistrationStatus"
-        },
-        "Status": {
-          "type": "string"
-        },
-        "RegistrationMethod": {
-          "type": "string",
-          "title": "Valid values for now are: 'console', 'terraform'. default would be 'console'"
-        },
-        "templateVersion": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverAzureOptions": {
-      "type": "object",
-      "properties": {
-        "accountName": {
-          "type": "string"
-        },
-        "azureCustomerId": {
-          "type": "string"
-        },
-        "azurePlanId": {
-          "type": "string"
-        },
-        "serviceAcct": {
-          "type": "string"
-        },
-        "partnerAcct": {
-          "type": "string"
-        },
-        "companyId": {
-          "type": "string"
-        },
-        "payerId": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverBudgetAlert": {
-      "type": "object",
-      "properties": {
-        "threshold": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/coverThreshold"
-          }
-        },
-        "channels": {
-          "$ref": "#/definitions/coverAlertChannels"
-        }
-      }
-    },
-    "apicoverCategory": {
-      "type": "object",
-      "properties": {
-        "display": {
-          "type": "string"
-        },
-        "query": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverCostCalculation": {
-      "type": "object",
-      "properties": {
-        "estCostAfterDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "estCostBeforeDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "otherDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "savingsPlanDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "estNetUnusedAmortizedCommitments": {
-          "type": "number",
-          "format": "double"
-        },
-        "reservedInstanceDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "usageTypes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apicoverUsageTypes"
-          }
-        }
-      }
-    },
-    "apicoverCostGroup": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "title": "cost group name"
-        }
-      }
-    },
-    "apicoverEBSDetails": {
-      "type": "object",
-      "properties": {
-        "currentEBSDetails": {
-          "$ref": "#/definitions/coverCurrentEBSDetails"
-        },
-        "upgradeEBSDetails": {
-          "$ref": "#/definitions/coverEBSRecommendationDetails"
-        }
-      }
-    },
-    "apicoverEC2Details": {
-      "type": "object",
-      "properties": {
-        "instanceType": {
-          "type": "string"
-        },
-        "tenancy": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverMemoryDBDetails": {
-      "type": "object",
-      "properties": {
-        "family": {
-          "type": "string"
-        },
-        "nodeType": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverRDSDetails": {
-      "type": "object",
-      "properties": {
-        "dbEdition": {
-          "type": "string"
-        },
-        "dbEngine": {
-          "type": "string"
-        },
-        "deploymentOptions": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        },
-        "instanceType": {
-          "type": "string"
-        },
-        "licenseModel": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverRecommendationDetail": {
-      "type": "object",
-      "properties": {
-        "recommendation": {
-          "type": "string"
-        },
-        "recommendedResourceType": {
-          "type": "string"
-        },
-        "estimatedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "estimatedSavings": {
-          "type": "number",
-          "format": "double"
-        },
-        "region": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverRedshiftDetails": {
-      "type": "object",
-      "properties": {
-        "currentGeneration": {
-          "type": "boolean"
-        },
-        "nodeType": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverResult": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverRole": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "costgroupsIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apicoverTagData": {
-      "type": "object",
-      "properties": {
-        "tagKey": {
-          "type": "string"
-        },
-        "tagValue": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apicoverUsageTypes": {
-      "type": "object",
-      "properties": {
-        "operation": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "unit": {
-          "type": "string"
-        },
-        "usageAmount": {
-          "type": "number",
-          "format": "double"
-        },
-        "usageType": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverUser": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/coverUserRole"
-          }
-        },
-        "invitedBy": {
-          "type": "object"
-        },
-        "lastUpdated": {
-          "type": "string"
-        },
-        "createdOn": {
-          "type": "string"
-        },
-        "avatar": {
-          "type": "string"
-        },
-        "activated": {
-          "type": "boolean"
-        },
-        "colorTheme": {
-          "type": "string"
-        }
-      }
-    },
-    "apicoverUtilizationData": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "format": "float"
-        }
-      }
-    },
-    "apigcpCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "title": "account data"
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "invoiceMonth": {
-          "type": "string",
-          "description": "The invoice.month of the lineitem, if applicable."
-        },
-        "service": {
-          "type": "string",
-          "description": "The service.Description of the lineitem, if applicable."
-        },
-        "sku": {
-          "type": "string",
-          "description": "The sku.Description of the lineitem, if applicable."
-        },
-        "region": {
-          "type": "string",
-          "description": "The location.region of the lineitem, if applicable."
-        },
-        "zone": {
-          "type": "string",
-          "description": "The location.zone of the lineitem, if applicable."
-        },
-        "creditsType": {
-          "type": "string",
-          "description": "The credits.type of the lineitem, if applicable."
-        },
-        "creditsName": {
-          "type": "string",
-          "description": "The credits.name of the lineitem, if applicable."
-        },
-        "usageUnit": {
-          "type": "string",
-          "description": "The usage.pricing_unit of the lineitem, if applicable."
-        },
-        "usageAmount": {
-          "type": "number",
-          "format": "double",
-          "description": "The usage.amount_in_pricing_units of the lineitem, if applicable."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The currency of the lineitem, if applicable."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The cost of the lineitem, if applicable."
-        }
-      },
-      "description": "see gcp billing data schema details:[https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables]",
-      "title": "Cost for Api Response"
-    },
-    "apilusterLabel": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The label id."
-        },
-        "name": {
-          "type": "string",
-          "description": "The label name."
-        },
-        "color": {
-          "type": "string",
-          "description": "The label color.\nformat: HEX color code ( #FF0000 )."
-        },
-        "description": {
-          "type": "string",
-          "description": "The label description."
-        },
-        "createdAt": {
-          "type": "string",
-          "title": "The label createdAt.\n\"created_at\": \"2023-10-27T10:00:00Z\"",
-          "readOnly": true
-        },
-        "updatedAt": {
-          "type": "string",
-          "title": "The label updatedAt.\n\"updated_at\": \"2023-10-27T10:00:00Z\"",
-          "readOnly": true
-        }
-      },
-      "title": "The message defines the label"
-    },
-    "apirippleAccessGroup": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "billingGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "description": "AccessGroup resource definition."
-    },
-    "apirippleOrg": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The unique name (or id) of the organization."
-        },
-        "email": {
-          "type": "string",
-          "description": "The registered email of the organization."
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "The metadata (key/value pair) of the organization. If hierarchy is supported, it will be\nseparated by '/', such as 'metakey/subkey=value'. See https://alphauslabs.github.io/blueapi/\nfor the list of supported attributes."
-        }
-      },
-      "description": "Org resource definition."
-    },
-    "apiripplev1InvoiceServiceDiscounts": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The invoice service discounts id."
-        },
-        "name": {
-          "type": "string",
-          "description": "The invoice service discount name.\nmust be 1-60 characters long."
-        },
-        "description": {
-          "type": "string",
-          "description": "The invoice service discount description.\nMaximum 150 characters long."
-        },
-        "setting": {
-          "$ref": "#/definitions/v1InvoiceServiceDiscountsSetting",
-          "description": "The invoice service discount setting."
-        },
-        "created": {
-          "type": "string",
-          "description": "Timestamp associated with the created.",
-          "readOnly": true
-        },
-        "updated": {
-          "type": "string",
-          "description": "Timestamp associated with the updated.",
-          "readOnly": true
-        }
-      },
-      "description": "InvoiceServiceDiscounts resource definition."
-    },
-    "apiwaveBudget": {
+    "apiWaveBudget": {
       "type": "object",
       "properties": {
         "id": {
@@ -29871,7 +29944,7 @@
       },
       "description": "Budget resource definition."
     },
-    "apiwaveBudgetAlert": {
+    "apiWaveBudgetAlert": {
       "type": "object",
       "properties": {
         "id": {
@@ -29883,7 +29956,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiwaveNotification"
+            "$ref": "#/definitions/apiWaveNotification"
           },
           "description": "notification setting."
         },
@@ -29891,14 +29964,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiwaveBudget"
+            "$ref": "#/definitions/apiWaveBudget"
           },
           "description": "budget setting."
         }
       },
       "description": "Budget resource definition."
     },
-    "apiwaveNotification": {
+    "apiWaveNotification": {
       "type": "object",
       "properties": {
         "id": {
@@ -30000,7 +30073,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiawsChartData"
+            "$ref": "#/definitions/apiAwsChartData"
           }
         }
       }
@@ -30676,7 +30749,7 @@
     "azurecspAzureCSPRecommendations": {
       "type": "object"
     },
-    "billingv1AccessGroup": {
+    "billingV1AccessGroup": {
       "type": "object",
       "properties": {
         "accessGroupId": {
@@ -30695,14 +30768,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/billingv1BillingGroup"
+            "$ref": "#/definitions/billingV1BillingGroup"
           },
           "description": "A list of billing groups contained in the access group."
         }
       },
       "description": "Defines the fields associated with a Wave access group."
     },
-    "billingv1AwsOptions": {
+    "billingV1AwsOptions": {
       "type": "object",
       "properties": {
         "useProFormaCur": {
@@ -30714,7 +30787,7 @@
         }
       }
     },
-    "billingv1AzureOptions": {
+    "billingV1AzureOptions": {
       "type": "object",
       "properties": {
         "resourceGroup": {
@@ -30732,7 +30805,7 @@
       },
       "title": "Optional. Azure-specific options"
     },
-    "billingv1BillingGroup": {
+    "billingV1BillingGroup": {
       "type": "object",
       "properties": {
         "billingInternalId": {
@@ -30771,7 +30844,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           },
           "title": "List of all accounts"
         },
@@ -30792,12 +30865,12 @@
           "title": "List of all additionalItems"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingv1AwsOptions",
+          "$ref": "#/definitions/billingV1AwsOptions",
           "title": "AWS-specific options"
         }
       }
     },
-    "billingv1InvoiceSettings": {
+    "billingV1InvoiceSettings": {
       "type": "object",
       "properties": {
         "invoiceNo": {
@@ -30884,7 +30957,7 @@
         }
       }
     },
-    "billingv1Tag": {
+    "billingV1Tag": {
       "type": "object",
       "properties": {
         "key": {
@@ -30903,7 +30976,7 @@
       },
       "title": "Individual tag definition for AddTagsToBillingGroup"
     },
-    "billingv1TagData": {
+    "billingV1TagData": {
       "type": "object",
       "properties": {
         "customerId": {
@@ -30925,7 +30998,7 @@
       },
       "title": "Response for tag request"
     },
-    "blueapiapiAccount": {
+    "blueapiApiAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -30958,7 +31031,7 @@
         }
       }
     },
-    "blueapiapiBudget": {
+    "blueapiApiBudget": {
       "type": "object",
       "properties": {
         "id": {
@@ -30977,7 +31050,7 @@
         }
       }
     },
-    "blueapiapiChartData": {
+    "blueapiApiChartData": {
       "type": "object",
       "properties": {
         "date": {
@@ -31004,7 +31077,7 @@
         }
       }
     },
-    "blueapiapiFeeDetails": {
+    "blueapiApiFeeDetails": {
       "type": "object",
       "properties": {
         "name": {
@@ -31020,7 +31093,7 @@
       },
       "description": "FeeDetails resource definition."
     },
-    "blueapiapiInvoiceSettings": {
+    "blueapiApiInvoiceSettings": {
       "type": "object",
       "properties": {
         "address": {
@@ -31073,7 +31146,7 @@
       },
       "description": "InvoiceSettings resource definition."
     },
-    "blueapiapiNotification": {
+    "blueapiApiNotification": {
       "type": "object",
       "properties": {
         "id": {
@@ -31092,11 +31165,11 @@
           "type": "boolean"
         },
         "account": {
-          "$ref": "#/definitions/blueapiapiNotificationAccount"
+          "$ref": "#/definitions/blueapiApiNotificationAccount"
         }
       }
     },
-    "blueapiapiNotificationAccount": {
+    "blueapiApiNotificationAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31107,7 +31180,7 @@
         }
       }
     },
-    "blueapiapiRole": {
+    "blueapiApiRole": {
       "type": "object",
       "properties": {
         "name": {
@@ -31131,7 +31204,7 @@
         }
       }
     },
-    "blueapiapiUser": {
+    "blueapiApiUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -31151,7 +31224,7 @@
         }
       }
     },
-    "blueapiapiUtilizationData": {
+    "blueapiApiUtilizationData": {
       "type": "object",
       "properties": {
         "id": {
@@ -31161,12 +31234,12 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiChartData"
+            "$ref": "#/definitions/blueapiApiChartData"
           }
         }
       }
     },
-    "blueapibillingv1InvoiceServiceDiscounts": {
+    "blueapiBillingV1InvoiceServiceDiscounts": {
       "type": "object",
       "properties": {
         "id": {
@@ -31192,7 +31265,7 @@
       },
       "description": "Streaming response message for the InvoiceServiceDiscounts rpc."
     },
-    "blueapibillingv1ListExchangeRatesResponse": {
+    "blueapiBillingV1ListExchangeRatesResponse": {
       "type": "object",
       "properties": {
         "month": {
@@ -31218,22 +31291,22 @@
       },
       "description": "Response message for the ListExchangeRates rpc."
     },
-    "blueapicostv1CostItem": {
+    "blueapiCostV1CostItem": {
       "type": "object",
       "properties": {
         "aws": {
-          "$ref": "#/definitions/apiawsCost"
+          "$ref": "#/definitions/apiAwsCost"
         },
         "gcp": {
-          "$ref": "#/definitions/apigcpCost"
+          "$ref": "#/definitions/apiGcpCost"
         },
         "azure": {
-          "$ref": "#/definitions/apiazureCost"
+          "$ref": "#/definitions/apiAzureCost"
         }
       },
       "description": "Response message wrapper for cloud costs."
     },
-    "blueapicoverv1CostItem": {
+    "blueapiCoverV1CostItem": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31316,15 +31389,15 @@
       },
       "description": "Response message wrapper for cloud costs."
     },
-    "blueapicoverv1GetUserResponse": {
+    "blueapiCoverV1GetUserResponse": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apicoverUser"
+          "$ref": "#/definitions/apiCoverUser"
         }
       }
     },
-    "blueapicoverv1ListExchangeRatesResponse": {
+    "blueapiCoverV1ListExchangeRatesResponse": {
       "type": "object",
       "properties": {
         "orgId": {
@@ -31340,7 +31413,7 @@
       },
       "title": "Response message for ListExchangeRates"
     },
-    "blueapicoverv1Resource": {
+    "blueapiCoverV1Resource": {
       "type": "object",
       "properties": {
         "date": {
@@ -31386,7 +31459,7 @@
         }
       }
     },
-    "blueapiflowv1DailyUtilization": {
+    "blueapiFlowV1DailyUtilization": {
       "type": "object",
       "properties": {
         "currentDate": {
@@ -31401,7 +31474,7 @@
       },
       "description": "Daily utilization data for a specific date range."
     },
-    "blueapiflowv1GetInfoResponse": {
+    "blueapiFlowV1GetInfoResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31410,7 +31483,7 @@
       },
       "description": "Response message for the Flow.GetInfo rpc."
     },
-    "blueapigcv1Resource": {
+    "blueapiGcV1Resource": {
       "type": "object",
       "properties": {
         "id": {
@@ -31550,7 +31623,7 @@
         }
       }
     },
-    "blueapiorgv1CreateOrgRequest": {
+    "blueapiOrgV1CreateOrgRequest": {
       "type": "object",
       "properties": {
         "email": {
@@ -31596,11 +31669,11 @@
       },
       "description": "Request message for the Organization.CreateOrg rpc."
     },
-    "blueapiorgv1CreateOrgResponse": {
+    "blueapiOrgV1CreateOrgResponse": {
       "type": "object",
       "properties": {
         "org": {
-          "$ref": "#/definitions/apirippleOrg"
+          "$ref": "#/definitions/apiRippleOrg"
         },
         "password": {
           "type": "string"
@@ -31608,7 +31681,7 @@
       },
       "description": "Response message for the Organization.CreateOrg rpc."
     },
-    "blueapipricingv1GetInfoResponse": {
+    "blueapiPricingV1GetInfoResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31617,7 +31690,7 @@
       },
       "description": "Response message for the Pricing.GetInfo rpc."
     },
-    "blueapiprismv1TestResponse": {
+    "blueapiPrismV1TestResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31625,7 +31698,7 @@
         }
       }
     },
-    "blueapivortexv1CreateOrgRequest": {
+    "blueapiVortexV1CreateOrgRequest": {
       "type": "object",
       "properties": {
         "name": {
@@ -31636,7 +31709,7 @@
         }
       }
     },
-    "blueapivortexv1CreateOrgResponse": {
+    "blueapiVortexV1CreateOrgResponse": {
       "type": "object",
       "properties": {
         "orgId": {
@@ -31650,7 +31723,7 @@
         }
       }
     },
-    "blueapivortexv1GetUserResponse": {
+    "blueapiVortexV1GetUserResponse": {
       "type": "object",
       "properties": {
         "id": {
@@ -31667,7 +31740,7 @@
         }
       }
     },
-    "blueapivortexv1TestResponse": {
+    "blueapiVortexV1TestResponse": {
       "type": "object",
       "properties": {
         "message": {
@@ -31676,7 +31749,7 @@
       },
       "title": "Test only"
     },
-    "costv1CostAttribute": {
+    "costV1CostAttribute": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31693,7 +31766,7 @@
         }
       }
     },
-    "costv1ListCostFilters": {
+    "costV1ListCostFilters": {
       "type": "object",
       "properties": {
         "filterId": {
@@ -31978,7 +32051,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverBudgetAlert"
+            "$ref": "#/definitions/apiCoverBudgetAlert"
           },
           "title": "threshold(s) and its respective channel(s) to alert"
         },
@@ -32135,7 +32208,7 @@
           "type": "string"
         },
         "costgroup": {
-          "$ref": "#/definitions/apicoverCostGroup"
+          "$ref": "#/definitions/apiCoverCostGroup"
         },
         "startDate": {
           "type": "string"
@@ -32402,7 +32475,7 @@
           "format": "double"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -32441,35 +32514,35 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         },
         "eC2DiskUtilization": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         },
         "eC2MemoryUtilization": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         },
         "networkTrafficData": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         },
         "otherDetails": {
           "$ref": "#/definitions/CurrentEC2DetailsOtherDetails"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -32563,7 +32636,7 @@
           "format": "double"
         },
         "EstcostCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -32595,7 +32668,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -33293,10 +33366,10 @@
           "$ref": "#/definitions/coverEC2UpgadeDetails"
         },
         "currentCostCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         },
         "estCostCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -33385,7 +33458,7 @@
       "type": "object",
       "properties": {
         "ec2Options": {
-          "$ref": "#/definitions/apicoverEC2Details"
+          "$ref": "#/definitions/apiCoverEC2Details"
         },
         "elasticCacheOptions": {
           "$ref": "#/definitions/coverElasticCacheDetails"
@@ -33394,13 +33467,13 @@
           "$ref": "#/definitions/coverESDetails"
         },
         "rdsOptions": {
-          "$ref": "#/definitions/apicoverRDSDetails"
+          "$ref": "#/definitions/apiCoverRDSDetails"
         },
         "redshiftOptions": {
-          "$ref": "#/definitions/apicoverRedshiftDetails"
+          "$ref": "#/definitions/apiCoverRedshiftDetails"
         },
         "memoryDbOptions": {
-          "$ref": "#/definitions/apicoverMemoryDBDetails"
+          "$ref": "#/definitions/apiCoverMemoryDBDetails"
         },
         "recommendedNormalizedUnits": {
           "type": "integer",
@@ -33459,7 +33532,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         }
       }
@@ -33471,7 +33544,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -33505,7 +33578,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -33624,7 +33697,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverRecommendationDetail"
+            "$ref": "#/definitions/apiCoverRecommendationDetail"
           }
         },
         "currentCost": {
@@ -33675,7 +33748,7 @@
           "format": "int32"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -33921,7 +33994,7 @@
           "$ref": "#/definitions/coverLambdaRightSizingRecommendationDetails"
         },
         "ebsRightSizingRecommendationDetails": {
-          "$ref": "#/definitions/apicoverEBSDetails"
+          "$ref": "#/definitions/apiCoverEBSDetails"
         },
         "ecsRightSizingRecommendationDetails": {
           "$ref": "#/definitions/coverEcsRightSizingRecommendationDetails"
@@ -34338,14 +34411,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         },
         "netWorkIO": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUtilizationData"
+            "$ref": "#/definitions/apiCoverUtilizationData"
           }
         }
       }
@@ -34531,10 +34604,10 @@
           "$ref": "#/definitions/coverEC2UpgadeDetails"
         },
         "currentCostCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         },
         "estimatedCostCalculation": {
-          "$ref": "#/definitions/apicoverCostCalculation"
+          "$ref": "#/definitions/apiCoverCostCalculation"
         }
       }
     },
@@ -34545,7 +34618,7 @@
           "$ref": "#/definitions/coverUpgradeEC2Details"
         },
         "upgradeEBSDetails": {
-          "$ref": "#/definitions/apicoverEBSDetails"
+          "$ref": "#/definitions/apiCoverEBSDetails"
         },
         "upgradeRDSDetails": {
           "$ref": "#/definitions/coverRDSUpgradeDetails"
@@ -34676,6 +34749,81 @@
           }
         }
       }
+    },
+    "coverV1FeeDetails": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "orgId": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "account": {
+          "type": "string"
+        },
+        "month": {
+          "type": "string"
+        },
+        "lineType": {
+          "type": "string"
+        },
+        "feeType": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "started": {
+          "type": "string"
+        },
+        "timeInterval": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "currency": {
+          "type": "string"
+        },
+        "splitStatus": {
+          "type": "string"
+        },
+        "isAllocated": {
+          "type": "boolean"
+        },
+        "isApplied": {
+          "type": "boolean"
+        },
+        "unblendedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "sourceFee": {
+          "type": "string"
+        },
+        "lastUpdate": {
+          "type": "string"
+        }
+      },
+      "description": "Response message for GetFeeDetails, CreateFeeReallocation rpc."
+    },
+    "coverV1Status": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "FAILED"
+      ],
+      "default": "PENDING",
+      "title": "Status of upload file"
     },
     "coverViewData": {
       "type": "object",
@@ -34812,82 +34960,7 @@
         }
       }
     },
-    "coverv1FeeDetails": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "orgId": {
-          "type": "string"
-        },
-        "vendor": {
-          "type": "string"
-        },
-        "account": {
-          "type": "string"
-        },
-        "month": {
-          "type": "string"
-        },
-        "lineType": {
-          "type": "string"
-        },
-        "feeType": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "started": {
-          "type": "string"
-        },
-        "timeInterval": {
-          "type": "string"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "currency": {
-          "type": "string"
-        },
-        "splitStatus": {
-          "type": "string"
-        },
-        "isAllocated": {
-          "type": "boolean"
-        },
-        "isApplied": {
-          "type": "boolean"
-        },
-        "unblendedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "sourceFee": {
-          "type": "string"
-        },
-        "lastUpdate": {
-          "type": "string"
-        }
-      },
-      "description": "Response message for GetFeeDetails, CreateFeeReallocation rpc."
-    },
-    "coverv1Status": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "IN_PROGRESS",
-        "SUCCESS",
-        "FAILED"
-      ],
-      "default": "PENDING",
-      "title": "Status of upload file"
-    },
-    "flowv1SavingsPlanDetailsPurchase": {
+    "flowV1SavingsPlanDetailsPurchase": {
       "type": "object",
       "properties": {
         "payerId": {
@@ -34937,7 +35010,7 @@
       },
       "title": "Savings plan details to be purchased"
     },
-    "flowv1SavingsPlanRecommendation": {
+    "flowV1SavingsPlanRecommendation": {
       "type": "object",
       "properties": {
         "payerId": {
@@ -34987,6 +35060,20 @@
       },
       "title": "Savings plan recommendation details"
     },
+    "gcV1Org": {
+      "type": "object",
+      "properties": {
+        "orgId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
     "gcpGCPRecommendations": {
       "type": "object",
       "properties": {
@@ -35019,21 +35106,7 @@
         }
       }
     },
-    "gcv1Org": {
-      "type": "object",
-      "properties": {
-        "orgId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        }
-      }
-    },
-    "googlerpcStatus": {
+    "googleRpcStatus": {
       "type": "object",
       "properties": {
         "code": {
@@ -35312,11 +35385,11 @@
       "properties": {
         "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
       "additionalProperties": {},
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "protobufNullValue": {
       "type": "string",
@@ -35324,7 +35397,7 @@
         "NULL_VALUE"
       ],
       "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     },
     "protosOperation": {
       "type": "object",
@@ -35342,7 +35415,7 @@
           "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable."
         },
         "error": {
-          "$ref": "#/definitions/googlerpcStatus",
+          "$ref": "#/definitions/googleRpcStatus",
           "description": "The error result of the operation in case of failure or cancellation."
         },
         "response": {
@@ -35351,6 +35424,23 @@
         }
       },
       "description": "This resource represents a long-running operation that is the result of a\nnetwork API call."
+    },
+    "recommendationAwsAWSRecommendations": {
+      "type": "object",
+      "properties": {
+        "costExplorerRecommendations": {
+          "$ref": "#/definitions/awsCostExplorerRecommendations"
+        },
+        "costOptimizationHubRecommendations": {
+          "$ref": "#/definitions/awsCostOptimizationHubRecommendations"
+        },
+        "trustedAdvisorRecommendations": {
+          "$ref": "#/definitions/awsTrustedAdvisorRecommendations"
+        },
+        "resourceArn": {
+          "type": "string"
+        }
+      }
     },
     "recommendationOCTOGeneratedRecommendations": {
       "type": "object",
@@ -35370,7 +35460,7 @@
       "type": "object",
       "properties": {
         "awsRecommendations": {
-          "$ref": "#/definitions/recommendationawsAWSRecommendations"
+          "$ref": "#/definitions/recommendationAwsAWSRecommendations"
         },
         "gcpRecommendations": {
           "$ref": "#/definitions/gcpGCPRecommendations"
@@ -35449,23 +35539,6 @@
         }
       }
     },
-    "recommendationawsAWSRecommendations": {
-      "type": "object",
-      "properties": {
-        "costExplorerRecommendations": {
-          "$ref": "#/definitions/awsCostExplorerRecommendations"
-        },
-        "costOptimizationHubRecommendations": {
-          "$ref": "#/definitions/awsCostOptimizationHubRecommendations"
-        },
-        "trustedAdvisorRecommendations": {
-          "$ref": "#/definitions/awsTrustedAdvisorRecommendations"
-        },
-        "resourceArn": {
-          "type": "string"
-        }
-      }
-    },
     "rippleAssigned": {
       "type": "object",
       "properties": {
@@ -35505,7 +35578,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           },
           "description": "A list of accounts."
         },
@@ -35833,7 +35906,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           },
           "description": "List of all members under this payer."
         }
@@ -36454,7 +36527,7 @@
           "description": "Account id."
         },
         "serviceDiscounts": {
-          "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts",
+          "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts",
           "description": "service discount infomation."
         }
       },
@@ -37338,6 +37411,41 @@
         }
       }
     },
+    "v1AwsRispExportOptions": {
+      "type": "object",
+      "properties": {
+        "includeExpired": {
+          "type": "boolean",
+          "description": "Optional. Include expired RIs/SPs in the results. Default: false."
+        },
+        "language": {
+          "type": "string",
+          "description": "Optional. CSV header language: \"en\" or \"ja\". Default: \"en\"."
+        },
+        "queries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Report queries to include in the export.\nValid values: \"ri_summary\", \"sp_summary\", \"ri_usageaccount\", \"sp_usageaccount\".\nDefault when empty: all 4 reports are included."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Global column filter applied to all reports.\nSuperseded per-report by columns_by_query if that key is present."
+        },
+        "columnsByQuery": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AwsRispExportOptionsColumns"
+          },
+          "description": "Optional. Per-report column overrides.\nKeys must be valid query names (ri_summary, sp_summary, ri_usageaccount, sp_usageaccount)."
+        }
+      },
+      "description": "AWS RI/SP export options for ExportReport."
+    },
     "v1AzureAccount": {
       "type": "object",
       "properties": {
@@ -38035,7 +38143,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           },
           "description": "Lsit of accountId."
         },
@@ -39267,10 +39375,10 @@
       "type": "object",
       "properties": {
         "aws": {
-          "$ref": "#/definitions/apiawsCostAttribute"
+          "$ref": "#/definitions/apiAwsCostAttribute"
         },
         "azure": {
-          "$ref": "#/definitions/apiazureCostAttribute"
+          "$ref": "#/definitions/apiAzureCostAttribute"
         }
       },
       "description": "Response message for the Cost.ReadCostAttributes rpc."
@@ -39705,7 +39813,7 @@
           "title": "Invoice settings"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingv1AwsOptions",
+          "$ref": "#/definitions/billingV1AwsOptions",
           "title": "Optional. AWS-specific options"
         },
         "city": {
@@ -39751,7 +39859,7 @@
           "title": "Optional. Custom fields to add to the billing group"
         },
         "azureOptions": {
-          "$ref": "#/definitions/billingv1AzureOptions"
+          "$ref": "#/definitions/billingV1AzureOptions"
         }
       },
       "description": "Request message for the CreateBillingGroupMerged rpc."
@@ -39820,7 +39928,7 @@
           "title": "Invoice settings"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingv1AwsOptions",
+          "$ref": "#/definitions/billingV1AwsOptions",
           "title": "Optional. AWS-specific options"
         },
         "city": {
@@ -40127,7 +40235,7 @@
           "title": "Optional. Description of the forecast"
         },
         "costGroup": {
-          "$ref": "#/definitions/apicoverCostGroup",
+          "$ref": "#/definitions/apiCoverCostGroup",
           "title": "Required. Cost Group Id and Name"
         },
         "pastActualCostRange": {
@@ -40163,7 +40271,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apicoverCostGroup"
+          "$ref": "#/definitions/apiCoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -40616,7 +40724,7 @@
           "title": "Required"
         },
         "account": {
-          "$ref": "#/definitions/adminv1NotificationAccount",
+          "$ref": "#/definitions/adminV1NotificationAccount",
           "description": "Optional. only available Wave(Pro)."
         }
       },
@@ -41281,11 +41389,11 @@
           "title": "GCP Options"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apicoverAzureOptions",
+          "$ref": "#/definitions/apiCoverAzureOptions",
           "title": "Azure Options"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apicoverAwsOptions"
+          "$ref": "#/definitions/apiCoverAwsOptions"
         },
         "accountType": {
           "type": "string",
@@ -41942,6 +42050,16 @@
       },
       "description": "Response message for the ExportBillingGroupCsv rpc."
     },
+    "v1ExportReportResponse": {
+      "type": "object",
+      "properties": {
+        "emailSent": {
+          "type": "boolean",
+          "description": "True if the export email was successfully queued for delivery."
+        }
+      },
+      "description": "Response message for ExportReport."
+    },
     "v1ExportServiceDiscountsRequest": {
       "type": "object",
       "properties": {
@@ -42118,7 +42236,7 @@
       "type": "object",
       "properties": {
         "accessGroup": {
-          "$ref": "#/definitions/billingv1AccessGroup"
+          "$ref": "#/definitions/billingV1AccessGroup"
         }
       },
       "description": "Response message for the Billing.GetAccessGroup rpc."
@@ -42156,7 +42274,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiapiBudget"
+          "$ref": "#/definitions/blueapiApiBudget"
         }
       },
       "title": "Response message for GetAccountBudget"
@@ -42227,7 +42345,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverTagData"
+            "$ref": "#/definitions/apiCoverTagData"
           }
         }
       },
@@ -42379,7 +42497,7 @@
       "type": "object",
       "properties": {
         "billingGroup": {
-          "$ref": "#/definitions/billingv1BillingGroup"
+          "$ref": "#/definitions/billingV1BillingGroup"
         }
       },
       "description": "Response message for the Billing.GetBillingGroup rpc."
@@ -42465,7 +42583,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverCategory"
+            "$ref": "#/definitions/apiCoverCategory"
           }
         }
       }
@@ -42517,7 +42635,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           },
           "description": "Optional. accounts that applied to the CustomizedBillingService　config."
         }
@@ -42617,7 +42735,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/costv1CostAttribute"
+            "$ref": "#/definitions/costV1CostAttribute"
           },
           "description": "The cost attributes."
         }
@@ -42663,7 +42781,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apicoverCostGroup"
+          "$ref": "#/definitions/apiCoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -42794,14 +42912,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverResult"
+            "$ref": "#/definitions/apiCoverResult"
           }
         },
         "tagData": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverTagData"
+            "$ref": "#/definitions/apiCoverTagData"
           }
         }
       },
@@ -43301,7 +43419,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiAccount"
+            "$ref": "#/definitions/blueapiApiAccount"
           },
           "description": "Optional. accounts that applied to the CustomizedBillingService　config."
         }
@@ -43693,7 +43811,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverRole"
+            "$ref": "#/definitions/apiCoverRole"
           }
         }
       }
@@ -44016,7 +44134,7 @@
       "type": "object",
       "properties": {
         "recommendationData": {
-          "$ref": "#/definitions/apicoverAWSRecommendations"
+          "$ref": "#/definitions/apiCoverAWSRecommendations"
         }
       }
     },
@@ -44265,14 +44383,14 @@
       "type": "object",
       "properties": {
         "recommendation": {
-          "$ref": "#/definitions/flowv1SavingsPlanRecommendation",
+          "$ref": "#/definitions/flowV1SavingsPlanRecommendation",
           "title": "Recommendation details"
         },
         "purchases": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/flowv1SavingsPlanDetailsPurchase"
+            "$ref": "#/definitions/flowV1SavingsPlanDetailsPurchase"
           },
           "title": "List of purchase items"
         },
@@ -44385,7 +44503,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverTagData"
+            "$ref": "#/definitions/apiCoverTagData"
           }
         }
       },
@@ -44509,7 +44627,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiUtilizationData"
+            "$ref": "#/definitions/blueapiApiUtilizationData"
           }
         }
       },
@@ -44654,7 +44772,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverUser"
+            "$ref": "#/definitions/apiCoverUser"
           }
         }
       }
@@ -45109,7 +45227,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/costv1ListCostFilters"
+            "$ref": "#/definitions/costV1ListCostFilters"
           }
         }
       },
@@ -45265,21 +45383,21 @@
         "createdVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingv1InvoiceSettings"
+            "$ref": "#/definitions/billingV1InvoiceSettings"
           },
           "title": "setting used in invoice creation"
         },
         "savedVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingv1InvoiceSettings"
+            "$ref": "#/definitions/billingV1InvoiceSettings"
           },
           "title": "saved invoice setting for the month"
         },
         "defaultVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingv1InvoiceSettings"
+            "$ref": "#/definitions/billingV1InvoiceSettings"
           },
           "title": "billinggroup's default invoice setting"
         },
@@ -45388,7 +45506,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiNotification"
+            "$ref": "#/definitions/blueapiApiNotification"
           }
         }
       },
@@ -45608,7 +45726,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapigcv1Resource"
+            "$ref": "#/definitions/blueapiGcV1Resource"
           }
         }
       }
@@ -45620,7 +45738,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiapiRole"
+            "$ref": "#/definitions/blueapiApiRole"
           }
         }
       },
@@ -47240,11 +47358,11 @@
           "title": "GCP Options. Specific for GCP"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apicoverAzureOptions",
+          "$ref": "#/definitions/apiCoverAzureOptions",
           "title": "Azure Options. Specific for Azure"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apicoverAwsOptions",
+          "$ref": "#/definitions/apiCoverAwsOptions",
           "title": "Aws Options. Specific for Aws"
         }
       },
@@ -47363,7 +47481,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apicoverUser"
+          "$ref": "#/definitions/apiCoverUser"
         }
       }
     },
@@ -47538,7 +47656,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicoverAccount"
+            "$ref": "#/definitions/apiCoverAccount"
           }
         }
       }
@@ -48416,7 +48534,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/billingv1Tag"
+            "$ref": "#/definitions/billingV1Tag"
           },
           "title": "Tags associated with this customer"
         }
@@ -48760,7 +48878,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apicoverCostGroup"
+          "$ref": "#/definitions/apiCoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -49245,7 +49363,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apicoverUser"
+          "$ref": "#/definitions/apiCoverUser"
         }
       }
     },
@@ -49367,7 +49485,7 @@
           "title": "File name"
         },
         "status": {
-          "$ref": "#/definitions/coverv1Status",
+          "$ref": "#/definitions/coverV1Status",
           "title": "Status"
         }
       },
@@ -49461,7 +49579,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiflowv1DailyUtilization"
+            "$ref": "#/definitions/blueapiFlowV1DailyUtilization"
           },
           "title": "Array of daily utilization data for this Savings Plan"
         }


### PR DESCRIPTION
## Overview
Introduces a new `ExportReport` RPC for Ripple to export RI/SP utilization reports via email, 
with multi-vendor support (AWS, GCP, Azure) and backward-compatible defaults.

## Changes

### New ExportReport RPC
- Vendor-agnostic RPC for monthly RI/SP exports with optional email notification override
- Supports Amazon RI/SP summary and usage account reports with flexible query selection

### Multi-Vendor Support
- `vendor` field optional; empty defaults to AWS
- GCP/Azure recognized with clear error messaging for future implementation
- Extensible for additional vendors

### AWS RI/SP Options
- `include_expired`, `language` (en/ja) support
- Flexible report queries: ri_summary, sp_summary, ri_usageaccount, sp_usageaccount
- Per-report column filtering via `columns` / `columns_by_query`

### Documentation
- Updated OpenAPI/Swagger documentation with new endpoint and request/response schemas