### PR TITLE
Add RPCs for reservable resources and custom commitment plans

### DIFF
--- a/gc/v1/gc.proto
+++ b/gc/v1/gc.proto
@@ -87,7 +87,7 @@ service GuaranteedCommitments {
   }
 
 
- //DEVELOPER'S NOTE: FOR Infrastructure Plan
+ // DEVELOPER'S NOTE: FOR Infrastructure Plan
 
   // WORK-IN-PROGRESS: Retrieves a paginated list of reservable infrastructure resources for a segment.
   // Supports filtering, sorting, and a date range for usage aggregation.
@@ -160,7 +160,7 @@ service GuaranteedCommitments {
   }
 
 
- //DEVELOPER'S NOTE: FOR Infrastructure Plan and custom (top-down) commitment plan
+ // DEVELOPER'S NOTE: FOR Infrastructure Plan and custom (top-down) commitment plan
 
   // WORK-IN-PROGRESS: Retrieves the available commitment types for a given provider.
   rpc GetAvailableCommitmentTypes(GetAvailableCommitmentTypesRequest) returns (GetAvailableCommitmentTypesResponse) {
@@ -169,7 +169,7 @@ service GuaranteedCommitments {
     };
   }
 
- //DEVELOPER'S NOTE: FOR Infrastructure Plan and custom (top-down) commitment plan
+ // DEVELOPER'S NOTE: FOR Infrastructure Plan and custom (top-down) commitment plan
 
   // WORK-IN-PROGRESS: Creates a custom (top-down) commitment purchase plan.
   rpc CreateCustomCommitmentPlan(CreateCustomCommitmentPlanRequest) returns (DefaultPurchasePlan) {
@@ -1217,7 +1217,11 @@ message GetResourceDailyUsageResponse {
 // It extends the basic resource shape with usage metrics, daily usage breakdown,
 // and hardware/catalog attributes needed for the Reservable Infrastructure view.
 message ReservableResource {
-  // Composite ID: "{resource_id}|{catalog_sku_org_id}|{catalog_sku_id}".
+  // Composite ID formatted as
+  // "{url_encoded_resource_id}|{url_encoded_catalog_sku_org_id}|{url_encoded_catalog_sku_id}".
+  // Each component must be URL/percent-encoded before concatenation so embedded "|"
+  // characters do not break parsing. Consumers must split on "|" and URL-decode each part.
+ 
   string id = 1;
   string resourceId = 2;
   string billingAccountId = 3;

--- a/gc/v1/gc.proto
+++ b/gc/v1/gc.proto
@@ -86,6 +86,17 @@ service GuaranteedCommitments {
     };
   }
 
+
+ //DEVELOPER'S NOTE: FOR Infrastructure Plan
+
+  // WORK-IN-PROGRESS: Retrieves a paginated list of reservable infrastructure resources for a segment.
+  // Supports filtering, sorting, and a date range for usage aggregation.
+  rpc ListReservableResources(ListReservableResourcesRequest) returns (ListReservableResourcesResponse) {
+    option (google.api.http) = {
+      get: "/v1/commitments/resources"
+    };
+  }
+
   // ####################### SEGMENTS #######################
 
   // WORK-IN-PROGRESS: Do not use. Retrieves all segments for the specified organization and provider.
@@ -147,6 +158,27 @@ service GuaranteedCommitments {
       delete: "/v1/commitments/purchaseplans/draft/{draftPlanId}"
     };
   }
+
+
+ //DEVELOPER'S NOTE: FOR Infrastructure Plan and custom (top-down) commitment plan
+
+  // WORK-IN-PROGRESS: Retrieves the available commitment types for a given provider.
+  rpc GetAvailableCommitmentTypes(GetAvailableCommitmentTypesRequest) returns (GetAvailableCommitmentTypesResponse) {
+    option (google.api.http) = {
+      get: "/v1/commitments/purchaseplans/availabletypes"
+    };
+  }
+
+ //DEVELOPER'S NOTE: FOR Infrastructure Plan and custom (top-down) commitment plan
+
+  // WORK-IN-PROGRESS: Creates a custom (top-down) commitment purchase plan.
+  rpc CreateCustomCommitmentPlan(CreateCustomCommitmentPlanRequest) returns (DefaultPurchasePlan) {
+    option (google.api.http) = {
+      post: "/v1/commitments/purchaseplans/custom"
+      body: "*"
+    };
+  }
+
   // ------------------------ ONBOARDING ------------------------
 
   // WORK-IN-PROGRESS: Registers a new child organization under the channel partner.
@@ -430,6 +462,26 @@ message GetResourceDailyUsageRequest {
   int32 pageSize = 6;
 }
 
+message ListReservableResourcesRequest {
+  // // Required. The segment ID to scope the query to.
+  // string segmentId = 1;
+  // // Optional. Field to sort by. Example: "ondemand_cost".
+  // string orderBy = 2;
+  // // Optional. If true, sort in descending order.
+  // bool desc = 3;
+  // // Optional. URL-encoded JSON filter expression.
+  // // Example (decoded): {"and":[{"and":[{"field":"covered_usage","op":"<","value":1}]},{"and":[{"field":"is_reservable","op":"=","value":"true"}]}]}
+  // string filter = 4;
+  // // Required. Start of the usage lookback window (YYYY-MM-DD).
+  // string startDate = 5;
+  // // Required. End of the usage lookback window (YYYY-MM-DD).
+  // string endDate = 6;
+  // // Optional. Page number (1-based).
+  // int32 page = 7;
+  // // Optional. Number of results per page.
+  // int32 pageSize = 8;
+}
+
 message ListPurchasePlansBySegmentRequest {
 }
 
@@ -637,6 +689,60 @@ message ListDraftPurchasePlansRequest {
 message DeleteDraftPurchasePlanRequest {
   // Required. The draft plan ID to delete.
   string draftPlanId = 1;
+}
+
+message GetAvailableCommitmentTypesRequest {
+  // Required. The cloud provider to query available types for.
+  // Acceptable values: "aws", "azure", "gcp".
+  string provider = 1;
+}
+
+// CreateCustomCommitmentPlanRequest creates a new top-down custom commitment plan.
+message CreateCustomCommitmentPlanRequest {
+  // Required. The cloud provider. Acceptable values: "aws", "azure", "gcp".
+  string provider = 1;
+  // Required. ISO 8601 lookback window start timestamp (e.g. "2026-04-09T02:43:39.717Z").
+  string startDate = 2;
+  // Required. ISO 8601 lookback window end timestamp (e.g. "2026-04-16T02:43:39.717Z").
+  string endDate = 3;
+  // Required. The segment ID to scope the plan to.
+  string segmentId = 4;
+  // Plan status. Use "draft" to save without submitting.
+  // Acceptable values: "draft", "submitted".
+  string status = 5;
+  // Optional. Human-readable description for the plan.
+  string description = 6;
+  // Required. Human-readable name for the plan.
+  string name = 7;
+  // List of contract specifications to include in the plan.
+  // Each entry selects a commitment category, term, payment option, and optional properties.
+  //
+  // Acceptable commitment_type values:
+  //   "aws/AmazonEC2", "aws/AmazonRDS", "aws/AmazonElastiCache",
+  //   "aws/savingsplan/Compute", "aws/savingsplan/EC2Instance", "aws/savingsplan/Database"
+  //
+  // Acceptable term values:
+  //   "thirty_day_gris"  - 30-day Archera Insured (leased: true)
+  //   "one_year_gris"    - 1-year Archera Insured (leased: true)
+  //   "one_year"         - 1-year Native Uninsured (leased: false)
+  //   "three_year"       - 3-year Native Uninsured (leased: false)
+  //
+  // Acceptable payment_option values:
+  //   "no_upfront", "partial_upfront", "all_upfront"
+  //   Note: "partial_upfront" and "all_upfront" are not available for 30-day terms.
+  //
+  // Acceptable properties keys:
+  //   "leased" (bool)          - true for Archera Insured terms, false for Native terms.
+  //   "offering_class" (string) - only for "aws/AmazonEC2"; "convertible" or "standard".
+  repeated ContractSpec includedContractSpecs = 8;
+  // List of contract term keys included in the plan.
+  // Acceptable values: "thirty_day_gris", "one_year_gris", "one_year", "three_year".
+  repeated string includedContractTerms = 9;
+  // Optional. Specific resource IDs to pin the plan to selected infrastructure resources.
+  // When populated, the server returns plan_type "infrastructure"; omit for a top-down
+  // "purchase" plan. IDs are composite strings in the format
+  // "{resource_id}|{catalog_sku_org_id}|{catalog_sku_id}" as returned by ListReservableResources.
+  repeated string resourceIds = 10;
 }
 
 message GetGuaranteedCommitmentTemplateUrlRequest {
@@ -1099,10 +1205,115 @@ message ResourceDailyUsage {
   string commonUsageType = 13;
   double coveredUsage = 14;
   double uptime = 15;
+  // Provider-specific usage type label (e.g. "BoxUsage:c5n.xlarge").
+  string providerUsageType = 16;
 }
 
 message GetResourceDailyUsageResponse {
   repeated ResourceDailyUsage dailyUsage = 1;
+}
+
+// ReservableResource is a fully-detailed infrastructure resource returned by ListReservableResources.
+// It extends the basic resource shape with usage metrics, daily usage breakdown,
+// and hardware/catalog attributes needed for the Reservable Infrastructure view.
+message ReservableResource {
+  // Composite ID: "{resource_id}|{catalog_sku_org_id}|{catalog_sku_id}".
+  string id = 1;
+  string resourceId = 2;
+  string billingAccountId = 3;
+  string subAccountId = 4;
+  // Cloud provider string, e.g. "aws".
+  string provider = 5;
+  string providerResourceId = 6;
+  string providerService = 7;
+  string providerSkuId = 8;
+  bool isSpot = 9;
+  bool isReservable = 10;
+  // Display name (nullable).
+  google.protobuf.Value name = 11;
+  // Resource group (nullable).
+  google.protobuf.Value resourceGroup = 12;
+  string usageEnd = 13;
+  string usageStart = 14;
+  google.protobuf.Struct tags = 15;
+  google.protobuf.Struct providerTags = 16;
+  google.protobuf.Struct userTags = 17;
+  string createdAt = 18;
+  string updatedAt = 19;
+  string instanceId = 20;
+  // Availability zone (nullable).
+  google.protobuf.Value availabilityZone = 21;
+  // Cache engine (nullable).
+  google.protobuf.Value cacheEngine = 22;
+  string catalogSkuId = 23;
+  string catalogSkuOrgId = 24;
+  bool classicNetworkingSupport = 25;
+  string clockSpeed = 26;
+  string commonUsageType = 27;
+  // Fraction of usage covered by existing commitments (0.0–1.0).
+  double coveredUsage = 28;
+  // Database engine (nullable).
+  google.protobuf.Value databaseEngine = 29;
+  string dedicatedEbsThroughput = 30;
+  // Description (nullable).
+  google.protobuf.Value description = 31;
+  string ecu = 32;
+  bool enhancedNetworkingSupported = 33;
+  string family = 34;
+  string fullRegionName = 35;
+  bool hasOndemandTerms = 36;
+  string iconUrl = 37;
+  string integrationId = 38;
+  bool intelAvx2Available = 39;
+  bool intelAvxAvailable = 40;
+  bool intelTurboAvailable = 41;
+  // IO descriptor (nullable).
+  google.protobuf.Value io = 42;
+  bool isCurrentGeneration = 43;
+  // Multi-AZ flag (nullable).
+  google.protobuf.Value isMultiAz = 44;
+  string licenseModel = 45;
+  string locationType = 46;
+  // Memory in bytes as a string, e.g. "11274289152.0".
+  string memory = 47;
+  // SKU name (nullable).
+  google.protobuf.Value skuName = 48;
+  string skuTitle = 49;
+  double netCost = 50;
+  double netSavings = 51;
+  string networkPerformance = 52;
+  string normalizationSizeFactor = 53;
+  double ondemandCost = 54;
+  string ondemandUsageUnit = 55;
+  string operatingSystem = 56;
+  string operation = 57;
+  string physicalProcessor = 58;
+  string preInstalledSw = 59;
+  string priceCurrency = 60;
+  string processorArchitecture = 61;
+  string processorFeatures = 62;
+  string publicationDate = 63;
+  string region = 64;
+  string service = 65;
+  string source = 66;
+  string storage = 67;
+  // Tax type (nullable).
+  google.protobuf.Value taxType = 68;
+  string tenancy = 69;
+  // Fraction of time the resource was running during the lookback period.
+  double uptime = 70;
+  string usageType = 71;
+  string vcpu = 72;
+  string version = 73;
+  bool vpcNetworkingSupport = 74;
+  string instanceType = 75;
+  string instanceTypeFamily = 76;
+  // Per-day usage breakdown for the requested date range.
+  repeated ResourceDailyUsage dailyUsages = 77;
+}
+
+message ListReservableResourcesResponse {
+  repeated ReservableResource resources = 1;
 }
 
 message Segment {
@@ -1285,6 +1496,14 @@ message DefaultPurchasePlan {
   repeated string flaggedActions = 50;
   string metaPlanId = 51;
   string coverageId = 52;
+
+  // Monthly cost breakdowns (returned by CreateCustomCommitmentPlan and related endpoints)
+  double monthlyAfterCost = 53;
+  double monthlyAmortizedCost = 54;
+  double monthlyBeforeCost = 55;
+  double monthlyFee = 56;
+  // All term keys present across the plan's line items.
+  repeated string allTerms = 57;
 }
 
 message ListPurchasePlansBySegmentResponse {
@@ -1513,6 +1732,13 @@ message DeleteDraftPurchasePlanResponse {
   string planId = 1;
   // Indicates if the plan was successfully deleted
   bool success = 2;
+}
+
+message GetAvailableCommitmentTypesResponse {
+  // List of available commitment type identifiers for the requested provider.
+  // Example values: "aws/AmazonEC2", "aws/AmazonRDS", "aws/AmazonElastiCache",
+  // "aws/savingsplan/Compute", "aws/savingsplan/EC2Instance", "aws/savingsplan/Database".
+  repeated string types = 1;
 }
 
 message GetGuaranteedCommitmentTemplateUrlResponse {

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -153,7 +153,7 @@
                   "$ref": "#/definitions/v1ListAccountGroupsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListAccountGroupsResponse"
@@ -162,7 +162,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -185,7 +185,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -216,7 +216,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -250,7 +250,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -283,7 +283,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -304,7 +304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -338,7 +338,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -368,7 +368,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -402,7 +402,7 @@
                   "$ref": "#/definitions/v1DefaultCostAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1DefaultCostAccess"
@@ -411,7 +411,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -434,7 +434,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -465,7 +465,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -495,7 +495,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -528,7 +528,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -561,7 +561,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -592,7 +592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -613,7 +613,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -647,7 +647,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -684,7 +684,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -714,7 +714,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -754,7 +754,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -788,7 +788,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -809,7 +809,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -843,7 +843,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -858,13 +858,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiNotification"
+              "$ref": "#/definitions/blueapiapiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -892,13 +892,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiNotification"
+              "$ref": "#/definitions/blueapiapiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -936,7 +936,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -967,13 +967,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiNotification"
+              "$ref": "#/definitions/blueapiapiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1013,7 +1013,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1042,7 +1042,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1075,7 +1075,7 @@
                   "$ref": "#/definitions/v1Announcement"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Announcement"
@@ -1084,7 +1084,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1116,7 +1116,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1163,7 +1163,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1210,7 +1210,7 @@
                   "$ref": "#/definitions/apiApiClient"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiApiClient"
@@ -1219,7 +1219,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1240,7 +1240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1275,7 +1275,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1307,7 +1307,7 @@
                   "$ref": "#/definitions/apiGroupRootUser"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiGroupRootUser"
@@ -1316,7 +1316,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1337,7 +1337,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1370,7 +1370,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1400,7 +1400,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1432,7 +1432,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1462,7 +1462,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1501,7 +1501,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1523,7 +1523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1558,7 +1558,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1590,7 +1590,7 @@
                   "$ref": "#/definitions/v1IpFilter"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1IpFilter"
@@ -1599,7 +1599,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1620,7 +1620,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1655,7 +1655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1687,7 +1687,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1726,7 +1726,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1758,7 +1758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1798,7 +1798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1838,7 +1838,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1872,7 +1872,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1905,7 +1905,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1938,7 +1938,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1971,7 +1971,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1995,13 +1995,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiRole"
+              "$ref": "#/definitions/blueapiapiRole"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2036,7 +2036,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2067,13 +2067,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiRole"
+              "$ref": "#/definitions/blueapiapiRole"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2120,7 +2120,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2150,7 +2150,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2182,7 +2182,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2213,19 +2213,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiUser"
+                  "$ref": "#/definitions/blueapiapiUser"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiUser"
+              "title": "Stream result of blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2240,13 +2240,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiUser"
+              "$ref": "#/definitions/blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2274,13 +2274,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiUser"
+              "$ref": "#/definitions/blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2310,7 +2310,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2336,13 +2336,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiUser"
+              "$ref": "#/definitions/blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2366,7 +2366,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2406,7 +2406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2437,7 +2437,7 @@
                   "$ref": "#/definitions/protosOperation"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of protosOperation"
@@ -2446,7 +2446,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2492,7 +2492,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2523,7 +2523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2556,7 +2556,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2590,13 +2590,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleOrg"
+              "$ref": "#/definitions/apirippleOrg"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2618,7 +2618,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2633,13 +2633,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiOrgV1CreateOrgResponse"
+              "$ref": "#/definitions/blueapiorgv1CreateOrgResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2650,7 +2650,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/blueapiOrgV1CreateOrgRequest"
+              "$ref": "#/definitions/blueapiorgv1CreateOrgRequest"
             }
           }
         ],
@@ -2674,7 +2674,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2709,7 +2709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2744,7 +2744,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2768,7 +2768,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2799,7 +2799,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2816,13 +2816,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiPricingV1GetInfoResponse"
+              "$ref": "#/definitions/blueapipricingv1GetInfoResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2845,7 +2845,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2885,7 +2885,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2914,19 +2914,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/apiRippleAccessGroup"
+                  "$ref": "#/definitions/apirippleAccessGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of apiRippleAccessGroup"
+              "title": "Stream result of apirippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2950,13 +2950,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleAccessGroup"
+              "$ref": "#/definitions/apirippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2990,7 +2990,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3029,7 +3029,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3053,13 +3053,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleAccessGroup"
+              "$ref": "#/definitions/apirippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3100,7 +3100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3134,7 +3134,7 @@
                   "$ref": "#/definitions/v1DataAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1DataAccess"
@@ -3143,7 +3143,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3166,7 +3166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3189,7 +3189,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3234,7 +3234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3279,7 +3279,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3319,7 +3319,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3356,7 +3356,7 @@
                   "$ref": "#/definitions/v1Activity"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Activity"
@@ -3365,7 +3365,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3398,7 +3398,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3429,7 +3429,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3460,7 +3460,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3498,7 +3498,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3537,7 +3537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3571,7 +3571,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3606,7 +3606,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3639,7 +3639,7 @@
                   "$ref": "#/definitions/v1AnomalyAlertData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AnomalyAlertData"
@@ -3648,7 +3648,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3671,7 +3671,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3702,7 +3702,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3733,7 +3733,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3773,7 +3773,7 @@
                   "$ref": "#/definitions/v1GetAlertsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetAlertsResponse"
@@ -3782,7 +3782,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3803,7 +3803,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3836,7 +3836,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3866,7 +3866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3896,7 +3896,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3937,7 +3937,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3970,7 +3970,7 @@
                   "$ref": "#/definitions/v1DiscountExpiryAlertData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1DiscountExpiryAlertData"
@@ -3979,7 +3979,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4002,7 +4002,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4033,7 +4033,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4064,7 +4064,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4105,7 +4105,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4137,7 +4137,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4168,7 +4168,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4209,7 +4209,7 @@
                   "$ref": "#/definitions/v1BudgetAlerts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1BudgetAlerts"
@@ -4218,7 +4218,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4252,7 +4252,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4261,7 +4261,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4295,7 +4295,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4304,7 +4304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4338,7 +4338,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4347,7 +4347,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4378,19 +4378,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverV1FeeDetails"
+                  "$ref": "#/definitions/coverv1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of coverV1FeeDetails"
+              "title": "Stream result of coverv1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4421,19 +4421,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverV1FeeDetails"
+                  "$ref": "#/definitions/coverv1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of coverV1FeeDetails"
+              "title": "Stream result of coverv1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4464,19 +4464,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverV1FeeDetails"
+                  "$ref": "#/definitions/coverv1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of coverV1FeeDetails"
+              "title": "Stream result of coverv1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4510,7 +4510,7 @@
                   "$ref": "#/definitions/v1FeeItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1FeeItem"
@@ -4519,7 +4519,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4553,7 +4553,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4562,7 +4562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4596,7 +4596,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4605,7 +4605,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4639,7 +4639,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4648,7 +4648,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4682,7 +4682,7 @@
                   "$ref": "#/definitions/v1AllocationItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AllocationItem"
@@ -4691,7 +4691,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4725,7 +4725,7 @@
                   "$ref": "#/definitions/v1CostAllocatorDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CostAllocatorDetails"
@@ -4734,7 +4734,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4755,7 +4755,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4789,7 +4789,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4820,7 +4820,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4858,7 +4858,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4888,7 +4888,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4927,7 +4927,7 @@
                   "$ref": "#/definitions/v1AnomalyData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AnomalyData"
@@ -4936,7 +4936,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4968,7 +4968,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5007,7 +5007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5057,19 +5057,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCoverV1Resource"
+                  "$ref": "#/definitions/blueapicoverv1Resource"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCoverV1Resource"
+              "title": "Stream result of blueapicoverv1Resource"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5103,7 +5103,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5136,7 +5136,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5166,7 +5166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5200,7 +5200,7 @@
                   "$ref": "#/definitions/v1AccountAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountAccess"
@@ -5209,7 +5209,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5243,7 +5243,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5277,7 +5277,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5311,7 +5311,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5341,7 +5341,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5374,7 +5374,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5408,7 +5408,7 @@
                   "$ref": "#/definitions/v1AwsDailyRunHistory"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AwsDailyRunHistory"
@@ -5417,7 +5417,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5451,7 +5451,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5472,7 +5472,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5506,7 +5506,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5527,7 +5527,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5561,7 +5561,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5593,7 +5593,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5633,7 +5633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5667,7 +5667,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5700,7 +5700,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5724,7 +5724,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5758,7 +5758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5792,7 +5792,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5826,7 +5826,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5865,7 +5865,7 @@
                   "$ref": "#/definitions/v1ListBillingGroupCustomFieldResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListBillingGroupCustomFieldResponse"
@@ -5874,7 +5874,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5907,7 +5907,7 @@
                   "$ref": "#/definitions/v1GetBillingGroupAnnouncementsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetBillingGroupAnnouncementsResponse"
@@ -5916,7 +5916,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5949,7 +5949,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5983,7 +5983,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6014,7 +6014,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6052,7 +6052,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6100,7 +6100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6148,7 +6148,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6188,7 +6188,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6228,7 +6228,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6268,7 +6268,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6308,7 +6308,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6348,7 +6348,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6388,7 +6388,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6424,19 +6424,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/billingV1BillingGroup"
+                  "$ref": "#/definitions/billingv1BillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of billingV1BillingGroup"
+              "title": "Stream result of billingv1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6488,13 +6488,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/billingV1BillingGroup"
+              "$ref": "#/definitions/billingv1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6528,7 +6528,7 @@
                   "$ref": "#/definitions/v1AbcBillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AbcBillingGroup"
@@ -6537,7 +6537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6569,7 +6569,7 @@
                   "$ref": "#/definitions/v1AbcAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AbcAccount"
@@ -6578,7 +6578,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6617,7 +6617,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6650,7 +6650,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6680,7 +6680,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6710,7 +6710,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6750,7 +6750,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6790,7 +6790,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6821,7 +6821,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6861,7 +6861,7 @@
                   "$ref": "#/definitions/v1AccountInvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountInvoiceServiceDiscounts"
@@ -6870,7 +6870,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6903,7 +6903,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6943,7 +6943,7 @@
                   "$ref": "#/definitions/v1ChildBillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ChildBillingGroup"
@@ -6952,7 +6952,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6985,7 +6985,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7022,7 +7022,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7080,7 +7080,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7111,7 +7111,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7138,13 +7138,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/billingV1BillingGroup"
+              "$ref": "#/definitions/billingv1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7178,7 +7178,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7217,7 +7217,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7257,7 +7257,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7290,7 +7290,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7357,7 +7357,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7454,7 +7454,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7487,7 +7487,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7517,7 +7517,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7547,7 +7547,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7587,7 +7587,7 @@
                   "$ref": "#/definitions/v1ListBudgetsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListBudgetsResponse"
@@ -7596,7 +7596,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7629,7 +7629,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7660,7 +7660,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7693,7 +7693,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7723,7 +7723,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7753,7 +7753,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7793,7 +7793,7 @@
                   "$ref": "#/definitions/v1GetChannelsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetChannelsResponse"
@@ -7802,7 +7802,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7835,7 +7835,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7869,7 +7869,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7892,7 +7892,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7931,10 +7931,76 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
+        "tags": [
+          "GuaranteedCommitments"
+        ]
+      }
+    },
+    "/v1/commitments/purchaseplans/availabletypes": {
+      "get": {
+        "summary": "WORK-IN-PROGRESS: Retrieves the available commitment types for a given provider.",
+        "operationId": "GuaranteedCommitments_GetAvailableCommitmentTypes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetAvailableCommitmentTypesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "description": "Required. The cloud provider to query available types for.\nAcceptable values: \"aws\", \"azure\", \"gcp\".",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "GuaranteedCommitments"
+        ]
+      }
+    },
+    "/v1/commitments/purchaseplans/custom": {
+      "post": {
+        "summary": "WORK-IN-PROGRESS: Creates a custom (top-down) commitment purchase plan.",
+        "operationId": "GuaranteedCommitments_CreateCustomCommitmentPlan",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DefaultPurchasePlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "CreateCustomCommitmentPlanRequest creates a new top-down custom commitment plan.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateCustomCommitmentPlanRequest"
+            }
+          }
+        ],
         "tags": [
           "GuaranteedCommitments"
         ]
@@ -7954,7 +8020,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7986,7 +8052,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8018,7 +8084,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8058,7 +8124,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8089,7 +8155,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8103,6 +8169,29 @@
             }
           }
         ],
+        "tags": [
+          "GuaranteedCommitments"
+        ]
+      }
+    },
+    "/v1/commitments/resources": {
+      "get": {
+        "summary": "WORK-IN-PROGRESS: Retrieves a paginated list of reservable infrastructure resources for a segment.\nSupports filtering, sorting, and a date range for usage aggregation.",
+        "operationId": "GuaranteedCommitments_ListReservableResources",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListReservableResourcesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
         "tags": [
           "GuaranteedCommitments"
         ]
@@ -8122,7 +8211,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8173,7 +8262,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8204,7 +8293,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8231,13 +8320,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiLusterLabel"
+              "$ref": "#/definitions/apilusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8272,7 +8361,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8296,13 +8385,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiLusterLabel"
+              "$ref": "#/definitions/apilusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8339,19 +8428,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/apiLusterLabel"
+                  "$ref": "#/definitions/apilusterLabel"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of apiLusterLabel"
+              "title": "Stream result of apilusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8385,7 +8474,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8425,7 +8514,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8473,7 +8562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8517,7 +8606,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8571,7 +8660,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8616,7 +8705,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8653,7 +8742,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8700,7 +8789,7 @@
                   "$ref": "#/definitions/lusterContext"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of lusterContext"
@@ -8709,7 +8798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8749,7 +8838,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8770,7 +8859,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8802,7 +8891,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8834,7 +8923,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8864,7 +8953,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8896,7 +8985,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8936,7 +9025,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8976,7 +9065,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9016,7 +9105,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9056,7 +9145,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9096,7 +9185,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9136,7 +9225,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9176,7 +9265,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9216,7 +9305,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9256,7 +9345,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9295,7 +9384,7 @@
                   "$ref": "#/definitions/v1GetCostUsageV2Response"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetCostUsageV2Response"
@@ -9304,7 +9393,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9334,19 +9423,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCoverV1CostItem"
+                  "$ref": "#/definitions/blueapicoverv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCoverV1CostItem"
+              "title": "Stream result of blueapicoverv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9379,7 +9468,7 @@
                   "$ref": "#/definitions/v1Credit"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Credit"
@@ -9388,7 +9477,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9411,7 +9500,7 @@
                   "$ref": "#/definitions/v1CsvSetting"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CsvSetting"
@@ -9420,7 +9509,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9443,7 +9532,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9477,7 +9566,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9506,7 +9595,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9545,7 +9634,7 @@
                   "$ref": "#/definitions/v1CustomField"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CustomField"
@@ -9554,7 +9643,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9587,7 +9676,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9621,7 +9710,7 @@
                   "$ref": "#/definitions/v1GetCustomizedBillingServiceBillingGroupResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetCustomizedBillingServiceBillingGroupResponse"
@@ -9630,7 +9719,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9668,7 +9757,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9706,7 +9795,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9753,7 +9842,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9791,7 +9880,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9821,7 +9910,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9861,7 +9950,7 @@
                   "$ref": "#/definitions/rippleCustomizedBillingService"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of rippleCustomizedBillingService"
@@ -9870,7 +9959,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9904,7 +9993,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9937,7 +10026,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9970,7 +10059,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10004,7 +10093,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10045,7 +10134,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10093,7 +10182,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10133,7 +10222,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10165,7 +10254,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10204,7 +10293,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10236,7 +10325,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10268,7 +10357,7 @@
                   "$ref": "#/definitions/v1GetCostForecastsDataResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetCostForecastsDataResponse"
@@ -10277,7 +10366,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10309,7 +10398,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10338,7 +10427,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10367,7 +10456,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10406,7 +10495,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10440,7 +10529,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10473,7 +10562,7 @@
                   "$ref": "#/definitions/v1GetFreeFormatResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetFreeFormatResponse"
@@ -10482,7 +10571,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10520,7 +10609,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10557,7 +10646,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10576,6 +10665,45 @@
         ]
       }
     },
+    "/v1/hubs/{hubType}": {
+      "get": {
+        "summary": "(ALPHA) [HUB] Gets hub.",
+        "operationId": "Luster_GetHub",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/lusterHub"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "hubType",
+            "description": "Required. the hub type.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fieldMask",
+            "description": "Optional. field_mask\nsee more info: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Luster"
+        ]
+      }
+    },
     "/v1/hubs:read": {
       "post": {
         "summary": "(ALPHA) [HUB] Reads hubs.",
@@ -10590,7 +10718,7 @@
                   "$ref": "#/definitions/lusterHub"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of lusterHub"
@@ -10599,7 +10727,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10627,13 +10755,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiFlowV1GetInfoResponse"
+              "$ref": "#/definitions/blueapiflowv1GetInfoResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10655,7 +10783,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10677,7 +10805,7 @@
                   "$ref": "#/definitions/v1IntegrationStatus"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1IntegrationStatus"
@@ -10686,7 +10814,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10719,7 +10847,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10752,7 +10880,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10785,7 +10913,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10807,7 +10935,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10842,7 +10970,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10882,7 +11010,7 @@
                   "$ref": "#/definitions/apiInvoiceMessage"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiInvoiceMessage"
@@ -10891,7 +11019,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10931,7 +11059,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10963,7 +11091,7 @@
                   "$ref": "#/definitions/v1ListInvoiceTemplateResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListInvoiceTemplateResponse"
@@ -10972,7 +11100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10995,7 +11123,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11035,7 +11163,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11075,7 +11203,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11115,7 +11243,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11156,7 +11284,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11196,7 +11324,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11237,7 +11365,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11277,7 +11405,7 @@
                   "$ref": "#/definitions/v1ListInvoiceResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListInvoiceResponse"
@@ -11286,7 +11414,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11320,7 +11448,7 @@
                   "$ref": "#/definitions/v1TotalSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1TotalSection"
@@ -11329,7 +11457,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11363,7 +11491,7 @@
                   "$ref": "#/definitions/v1BillingGroupSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1BillingGroupSection"
@@ -11372,7 +11500,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11406,7 +11534,7 @@
                   "$ref": "#/definitions/v1OverViewSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1OverViewSection"
@@ -11415,7 +11543,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11449,7 +11577,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11471,7 +11599,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11493,7 +11621,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11531,7 +11659,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11553,7 +11681,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11575,7 +11703,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11614,7 +11742,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11647,7 +11775,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11670,7 +11798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11703,7 +11831,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11736,7 +11864,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11769,7 +11897,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11802,7 +11930,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11835,7 +11963,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11868,7 +11996,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11901,7 +12029,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11934,7 +12062,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11967,7 +12095,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12000,7 +12128,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12033,7 +12161,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12056,7 +12184,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12088,7 +12216,7 @@
                   "$ref": "#/definitions/v1Member"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Member"
@@ -12097,7 +12225,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12130,7 +12258,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12151,7 +12279,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12184,7 +12312,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12217,7 +12345,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12250,7 +12378,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12283,7 +12411,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12316,7 +12444,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12349,7 +12477,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12382,7 +12510,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12412,7 +12540,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12452,7 +12580,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12485,7 +12613,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12518,7 +12646,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12548,7 +12676,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12580,7 +12708,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12612,7 +12740,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12652,7 +12780,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12692,7 +12820,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12725,7 +12853,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12758,7 +12886,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12790,7 +12918,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12846,7 +12974,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12902,7 +13030,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12935,7 +13063,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12968,7 +13096,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13002,7 +13130,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13034,7 +13162,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13068,7 +13196,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13107,7 +13235,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13160,7 +13288,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13200,7 +13328,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13239,7 +13367,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13272,7 +13400,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13306,7 +13434,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13338,7 +13466,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13371,7 +13499,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13404,7 +13532,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13434,7 +13562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13464,7 +13592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13504,7 +13632,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13538,13 +13666,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1CreateOrgResponse"
+              "$ref": "#/definitions/blueapivortexv1CreateOrgResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13554,7 +13682,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1CreateOrgRequest"
+              "$ref": "#/definitions/blueapivortexv1CreateOrgRequest"
             }
           }
         ],
@@ -13577,7 +13705,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13598,7 +13726,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13625,13 +13753,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiCoverV1ListExchangeRatesResponse"
+              "$ref": "#/definitions/blueapicoverv1ListExchangeRatesResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13670,7 +13798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13720,19 +13848,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/gcV1Org"
+                  "$ref": "#/definitions/gcv1Org"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of gcV1Org"
+              "title": "Stream result of gcv1Org"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13765,7 +13893,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13797,7 +13925,7 @@
                   "$ref": "#/definitions/v1Product"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Product"
@@ -13806,7 +13934,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13839,7 +13967,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13872,7 +14000,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13905,7 +14033,7 @@
                   "$ref": "#/definitions/v1Project"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Project"
@@ -13914,7 +14042,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13947,7 +14075,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13978,7 +14106,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14009,7 +14137,7 @@
                   "$ref": "#/definitions/v1ListProjectToTeamResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListProjectToTeamResponse"
@@ -14018,7 +14146,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14050,7 +14178,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14082,7 +14210,7 @@
                   "$ref": "#/definitions/v1Prompt"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Prompt"
@@ -14091,7 +14219,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14123,7 +14251,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14155,7 +14283,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14190,7 +14318,7 @@
                   "$ref": "#/definitions/v1ListRecommendationResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListRecommendationResponse"
@@ -14199,7 +14327,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14232,7 +14360,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14281,7 +14409,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14314,7 +14442,7 @@
                   "$ref": "#/definitions/v1GetExecutionStatusResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetExecutionStatusResponse"
@@ -14323,7 +14451,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14346,7 +14474,7 @@
                   "$ref": "#/definitions/v1ListRecommendationResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListRecommendationResponse"
@@ -14355,7 +14483,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14472,7 +14600,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14505,7 +14633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14579,7 +14707,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14612,7 +14740,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14655,7 +14783,7 @@
                   "$ref": "#/definitions/v1RecommendationSummary"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1RecommendationSummary"
@@ -14664,7 +14792,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14697,7 +14825,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14718,7 +14846,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14751,7 +14879,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14810,7 +14938,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14842,7 +14970,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14861,6 +14989,40 @@
         ]
       }
     },
+    "/v1/reports:export": {
+      "post": {
+        "summary": "Exports a vendor report and delivers results via email notification channel.\nSupports multiple report types per vendor. For AWS, this covers RI/SP utilization reports.",
+        "operationId": "Cost_ExportReport",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ExportReportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Request message for ExportReport.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ExportReportRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
     "/v1/reportschedule": {
       "post": {
         "operationId": "Prism_CreateReportSchedule",
@@ -14875,7 +15037,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14907,7 +15069,7 @@
                   "$ref": "#/definitions/v1ReportSchedule"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ReportSchedule"
@@ -14916,7 +15078,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14949,7 +15111,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14989,7 +15151,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15022,7 +15184,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15053,7 +15215,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15094,7 +15256,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15128,7 +15290,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15173,7 +15335,7 @@
                   "$ref": "#/definitions/rippleReseller"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of rippleReseller"
@@ -15182,7 +15344,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15212,7 +15374,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15246,7 +15408,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15284,7 +15446,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15314,7 +15476,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15354,7 +15516,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15432,7 +15594,7 @@
                   "$ref": "#/definitions/v1ResourceAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ResourceAccount"
@@ -15441,7 +15603,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15480,7 +15642,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15543,7 +15705,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15569,13 +15731,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15609,7 +15771,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15643,7 +15805,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15678,7 +15840,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15708,7 +15870,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15746,7 +15908,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15786,7 +15948,7 @@
                   "$ref": "#/definitions/v1AccountInvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountInvoiceServiceDiscounts"
@@ -15795,7 +15957,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15836,7 +15998,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15876,7 +16038,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15906,7 +16068,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15936,7 +16098,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15974,7 +16136,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16008,13 +16170,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16052,7 +16214,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16076,13 +16238,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16122,7 +16284,7 @@
                   "$ref": "#/definitions/v1Service"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Service"
@@ -16131,7 +16293,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16171,7 +16333,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16202,19 +16364,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiBillingV1InvoiceServiceDiscounts"
+                  "$ref": "#/definitions/blueapibillingv1InvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiBillingV1InvoiceServiceDiscounts"
+              "title": "Stream result of blueapibillingv1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16248,7 +16410,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16280,7 +16442,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16312,7 +16474,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16344,7 +16506,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16374,7 +16536,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16414,7 +16576,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16448,7 +16610,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16480,7 +16642,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16519,7 +16681,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16552,7 +16714,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16586,7 +16748,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16625,7 +16787,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16655,7 +16817,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16695,7 +16857,7 @@
                   "$ref": "#/definitions/lusterSpace"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of lusterSpace"
@@ -16704,7 +16866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16735,19 +16897,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/billingV1TagData"
+                  "$ref": "#/definitions/billingv1TagData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of billingV1TagData"
+              "title": "Stream result of billingv1TagData"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16784,7 +16946,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16816,7 +16978,7 @@
                   "$ref": "#/definitions/v1Team"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Team"
@@ -16825,7 +16987,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16857,7 +17019,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16887,7 +17049,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16913,13 +17075,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiPrismV1TestResponse"
+              "$ref": "#/definitions/blueapiprismv1TestResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16936,13 +17098,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1TestResponse"
+              "$ref": "#/definitions/blueapivortexv1TestResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16973,7 +17135,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16994,7 +17156,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17027,7 +17189,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17050,7 +17212,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17083,7 +17245,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17116,7 +17278,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17149,7 +17311,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17193,7 +17355,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17226,7 +17388,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17286,7 +17448,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17319,7 +17481,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17352,7 +17514,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17382,7 +17544,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17412,7 +17574,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17452,7 +17614,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17473,7 +17635,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17506,7 +17668,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17536,7 +17698,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17566,7 +17728,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17606,7 +17768,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17636,7 +17798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17666,7 +17828,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17706,7 +17868,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17740,7 +17902,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17770,7 +17932,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17803,13 +17965,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1GetUserResponse"
+              "$ref": "#/definitions/blueapivortexv1GetUserResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17840,7 +18002,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17863,7 +18025,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17890,13 +18052,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiCoverV1GetUserResponse"
+              "$ref": "#/definitions/blueapicoverv1GetUserResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17925,7 +18087,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17956,7 +18118,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17995,7 +18157,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18033,7 +18195,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18066,7 +18228,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18087,7 +18249,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18120,7 +18282,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18153,7 +18315,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18186,7 +18348,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18209,7 +18371,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18249,7 +18411,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18296,7 +18458,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18329,7 +18491,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18359,7 +18521,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18389,7 +18551,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18429,7 +18591,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18468,7 +18630,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18507,7 +18669,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18547,7 +18709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18587,7 +18749,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18626,7 +18788,7 @@
                   "$ref": "#/definitions/v1Workflow"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Workflow"
@@ -18635,7 +18797,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18668,7 +18830,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18708,7 +18870,7 @@
                   "$ref": "#/definitions/v1ProxyCreateCompletionResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ProxyCreateCompletionResponse"
@@ -18717,7 +18879,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18751,7 +18913,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18781,7 +18943,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18822,7 +18984,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18859,19 +19021,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiAccount"
+                  "$ref": "#/definitions/blueapiapiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiAccount"
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18909,13 +19071,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18955,7 +19117,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18992,19 +19154,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiAccount"
+                  "$ref": "#/definitions/blueapiapiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiAccount"
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19050,7 +19212,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19082,13 +19244,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19133,7 +19295,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19164,13 +19326,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19217,7 +19379,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19257,7 +19419,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19305,7 +19467,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19353,7 +19515,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19401,7 +19563,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19449,7 +19611,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19489,7 +19651,7 @@
                   "$ref": "#/definitions/v1AdjustmentEntry"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AdjustmentEntry"
@@ -19498,7 +19660,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19539,7 +19701,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19577,19 +19739,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19623,13 +19785,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiWaveBudgetAlert"
+              "$ref": "#/definitions/apiwaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19667,7 +19829,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19698,13 +19860,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiWaveBudgetAlert"
+              "$ref": "#/definitions/apiwaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19743,13 +19905,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiWaveBudgetAlert"
+              "$ref": "#/definitions/apiwaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19796,7 +19958,7 @@
                   "$ref": "#/definitions/apiAccountOriginalResource"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiAccountOriginalResource"
@@ -19805,7 +19967,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19845,7 +20007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19898,7 +20060,7 @@
                   "$ref": "#/definitions/v1GetChildBillingGroupCustomizedBillingServiceResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetChildBillingGroupCustomizedBillingServiceResponse"
@@ -19907,7 +20069,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19945,7 +20107,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19993,7 +20155,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20031,7 +20193,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20078,7 +20240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20129,7 +20291,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20183,7 +20345,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20222,7 +20384,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20268,7 +20430,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20298,7 +20460,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20339,7 +20501,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20378,7 +20540,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20410,7 +20572,7 @@
                   "$ref": "#/definitions/v1CalculatorCostModifier"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CalculatorCostModifier"
@@ -20419,7 +20581,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20450,7 +20612,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20491,7 +20653,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20531,7 +20693,7 @@
                   "$ref": "#/definitions/v1ListCalculatorRunningAccountsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListCalculatorRunningAccountsResponse"
@@ -20540,7 +20702,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20580,7 +20742,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20641,7 +20803,7 @@
                   "$ref": "#/definitions/v1CostAttributeItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CostAttributeItem"
@@ -20650,7 +20812,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20690,7 +20852,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20721,7 +20883,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20762,7 +20924,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20799,7 +20961,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20846,7 +21008,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20894,7 +21056,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20932,19 +21094,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20984,7 +21146,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21031,7 +21193,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21078,7 +21240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21120,13 +21282,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiBillingV1ListExchangeRatesResponse"
+              "$ref": "#/definitions/blueapibillingv1ListExchangeRatesResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21151,46 +21313,6 @@
         ]
       }
     },
-    "/v1/{vendor}/export/reports:queue": {
-      "post": {
-        "summary": "Queues a vendor report export and delivers results via email notification channel.\nSupports multiple report types per vendor. For AWS, this covers RI/SP utilization reports.",
-        "operationId": "Cost_ExportReport",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ExportReportResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "vendor",
-            "description": "Optional. Cloud vendor.\nAccepted values: \"aws\", \"gcp\", \"azure\".\nIf empty, defaults to \"aws\" for backward compatibility.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CostExportReportBody"
-            }
-          }
-        ],
-        "tags": [
-          "Cost"
-        ]
-      }
-    },
     "/v1/{vendor}/forecasts": {
       "get": {
         "summary": "Fetches cost forecasts for the specified billing group. Includes historical cost (up to previous month) and forecasted cost (up to three months for now).",
@@ -21205,7 +21327,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21272,7 +21394,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21325,7 +21447,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21378,7 +21500,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21438,7 +21560,7 @@
                   "$ref": "#/definitions/waveAdjustment"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of waveAdjustment"
@@ -21447,7 +21569,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21487,7 +21609,7 @@
                   "$ref": "#/definitions/v1ReadInvoiceIdsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ReadInvoiceIdsResponse"
@@ -21496,7 +21618,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21534,19 +21656,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21584,19 +21706,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiAccount"
+                  "$ref": "#/definitions/blueapiapiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiAccount"
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21627,13 +21749,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21674,7 +21796,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21715,7 +21837,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21763,7 +21885,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21801,7 +21923,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21841,7 +21963,7 @@
                   "$ref": "#/definitions/v1GetPayerAccountImportHistoryResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetPayerAccountImportHistoryResponse"
@@ -21850,7 +21972,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21896,7 +22018,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21936,7 +22058,7 @@
                   "$ref": "#/definitions/v1PayerAccountExtended"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1PayerAccountExtended"
@@ -21945,7 +22067,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21985,7 +22107,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22024,7 +22146,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22071,7 +22193,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22118,7 +22240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22156,7 +22278,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22196,7 +22318,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22275,7 +22397,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22311,19 +22433,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22363,7 +22485,7 @@
                   "$ref": "#/definitions/apiCostTag"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiCostTag"
@@ -22372,7 +22494,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22418,7 +22540,7 @@
                   "$ref": "#/definitions/apiCostTag"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiCostTag"
@@ -22427,7 +22549,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22473,7 +22595,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22510,7 +22632,7 @@
                   "$ref": "#/definitions/v1TagsAddingSetting"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1TagsAddingSetting"
@@ -22519,7 +22641,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22554,7 +22676,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22599,7 +22721,7 @@
                   "$ref": "#/definitions/rippleUntaggedGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of rippleUntaggedGroup"
@@ -22608,7 +22730,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22648,7 +22770,7 @@
                   "$ref": "#/definitions/v1UsageCostsDrift"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1UsageCostsDrift"
@@ -22657,7 +22779,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22697,7 +22819,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -23036,7 +23158,7 @@
           "description": "Required\nValid values:\n`InvoiceCalculationStarted`,\n`InvoiceCalculationFinished`,\n`CurUpdatedAfterInvoice`.\n`AccountBudgetAlert`."
         },
         "account": {
-          "$ref": "#/definitions/adminV1NotificationAccount",
+          "$ref": "#/definitions/adminv1NotificationAccount",
           "description": "Optional. only available Wave(Pro)."
         }
       },
@@ -23285,7 +23407,7 @@
           "description": "Optional. groups to apply the invoices setting\nthis is ignored if allGroups is true."
         },
         "invoiceSetting": {
-          "$ref": "#/definitions/billingV1InvoiceSettings",
+          "$ref": "#/definitions/billingv1InvoiceSettings",
           "description": "Required. Invoice setting."
         }
       }
@@ -23444,7 +23566,7 @@
           "description": "Optional. groups to apply the invoices setting\nthis is ignored if allGroups is true."
         },
         "invoiceSetting": {
-          "$ref": "#/definitions/billingV1InvoiceSettings",
+          "$ref": "#/definitions/billingv1InvoiceSettings",
           "description": "Required. Invoice setting."
         }
       }
@@ -23927,7 +24049,7 @@
       "type": "object",
       "properties": {
         "invoiceServiceDiscounts": {
-          "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts",
+          "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts",
           "description": "Required. The updated invoice service discounts object."
         },
         "updateMask": {
@@ -24239,7 +24361,7 @@
       "type": "object",
       "properties": {
         "budgetAlert": {
-          "$ref": "#/definitions/apiWaveBudgetAlert",
+          "$ref": "#/definitions/apiwaveBudgetAlert",
           "description": "Required. Budget alert setting."
         }
       },
@@ -24249,7 +24371,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiApiBudget"
+          "$ref": "#/definitions/blueapiapiBudget"
         }
       },
       "title": "Request message for CreateAccountBudget"
@@ -24426,27 +24548,6 @@
         }
       },
       "description": "Request message for the ExportCostFiltersFile rpc."
-    },
-    "CostExportReportBody": {
-      "type": "object",
-      "properties": {
-        "month": {
-          "type": "string",
-          "description": "Required. Billing month in YYYY-MM format."
-        },
-        "notificationChannelIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. Notification channel IDs to deliver the report.\nIf empty, the MSP default notification channel configured in DynamoDB is used."
-        },
-        "awsOptions": {
-          "$ref": "#/definitions/v1AwsRispExportOptions",
-          "description": "Optional. Valid only for the `aws` vendor. AWS RI/SP export options.\n\nFuture vendor-specific options follow the same pattern (e.g. gcp_options, azure_options)."
-        }
-      },
-      "description": "Request message for ExportReport."
     },
     "CostGetCostReductionBody": {
       "type": "object",
@@ -24841,7 +24942,7 @@
       "type": "object",
       "properties": {
         "budgetAlert": {
-          "$ref": "#/definitions/apiWaveBudgetAlert",
+          "$ref": "#/definitions/apiwaveBudgetAlert",
           "description": "Required. Budget alert setting.\n\nSet only the setting value to be changed.\nFor example, If you want to change only daily value, set `{\"budget\":[{\"id\":\"daily\",\"value\":100,\"enabled\":true}}` as a parameter\nThe same goes for notification. If you want to change only email value, set `{\"notification\":[{\"id\":\"email\",\"destination\":\"budgetalert-example@alphaus.cloud\",\"enabled\":true}}` as a parameter"
         }
       },
@@ -24851,7 +24952,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiApiBudget"
+          "$ref": "#/definitions/blueapiapiBudget"
         }
       },
       "title": "Request message for UpdateAccountBudget"
@@ -25265,7 +25366,7 @@
           "title": "Optional. Description of the forecast"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup",
+          "$ref": "#/definitions/apicoverCostGroup",
           "title": "Optional. Cost Group Id and Name"
         },
         "pastActualCostRange": {
@@ -25359,11 +25460,11 @@
           "title": "GCP Options"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apiCoverAzureOptions",
+          "$ref": "#/definitions/apicoverAzureOptions",
           "title": "Azure Options"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apiCoverAwsOptions",
+          "$ref": "#/definitions/apicoverAwsOptions",
           "title": "AWS Options"
         },
         "accountType": {
@@ -27761,7 +27862,7 @@
         }
       }
     },
-    "adminV1NotificationAccount": {
+    "adminv1NotificationAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -27805,7 +27906,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiFeeDetails"
+            "$ref": "#/definitions/blueapiapiFeeDetails"
           },
           "title": "feeDetails: Includes details of re-caluclated fee data"
         },
@@ -27844,7 +27945,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           }
         }
       }
@@ -28003,374 +28104,6 @@
       },
       "description": "AuditExportData resource definition."
     },
-    "apiAwsChartData": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string"
-        },
-        "actualOndemand": {
-          "type": "number",
-          "format": "double"
-        },
-        "actualCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "utilization": {
-          "type": "number",
-          "format": "double"
-        }
-      }
-    },
-    "apiAwsCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "description": "The account being queried."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "type": {
-          "type": "string"
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "productCode": {
-          "type": "string",
-          "description": "The product code for an AWS service, such as `AmazonEC2`, `AmazonRDS`, etc. This can also be an Alphaus-specified custom value."
-        },
-        "serviceCode": {
-          "type": "string",
-          "description": "The CUR service code of the lineitem, if applicable. Sometimes, this is the same as `productCode`, a subset of `productCode`, an Alphaus-specified custom value, or empty."
-        },
-        "region": {
-          "type": "string",
-          "description": "The region of the lineitem, if applicable."
-        },
-        "zone": {
-          "type": "string",
-          "description": "The zone of the lineitem, if applicable."
-        },
-        "usageType": {
-          "type": "string",
-          "description": "The CUR usage type of the lineitem, if applicable."
-        },
-        "instanceType": {
-          "type": "string",
-          "description": "The CUR instance type of the lineitem, if applicable."
-        },
-        "operation": {
-          "type": "string",
-          "description": "The CUR operation of the lineitem, if applicable."
-        },
-        "invoiceId": {
-          "type": "string",
-          "description": "The AWS invoice ID of the lineitem, if applicable."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the lineitem, if applicable."
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "The resource id of the lineitem, if applicable. At the moment, this is not yet fully supported."
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "costCategories": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "usage": {
-          "type": "number",
-          "format": "double",
-          "description": "Only set when `description` and/or `resourceId` attributes are specified."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The true cost (calculated) for this lineitem."
-        },
-        "unblendedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "The unblended cost as reflected in the CUR for this lineitem."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The base currency for `cost`, `unblendedCost`, `effectiveCost`, `amortizedCost`. Always set to `USD`, CUR's default currency."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
-        },
-        "targetCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `cost`."
-        },
-        "targetUnblendedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `unblendedCost`."
-        },
-        "targetCurrency": {
-          "type": "string",
-          "description": "The currency set by `toCurrency`."
-        },
-        "effectiveCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "targetEffectiveCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `effectiveCost`."
-        },
-        "amortizedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "targetAmortizedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `amortizedCost`."
-        },
-        "tagId": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "string",
-          "description": "Get last update in UNIX time format."
-        },
-        "metadata": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiKeyValue"
-          },
-          "description": "Various metadata associated with this lineitem."
-        }
-      }
-    },
-    "apiAwsCostAttribute": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string"
-        },
-        "groupId": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "serviceCode": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "zone": {
-          "type": "string"
-        },
-        "usageType": {
-          "type": "string"
-        },
-        "instanceType": {
-          "type": "string"
-        },
-        "operation": {
-          "type": "string"
-        },
-        "invoiceId": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "resourceId": {
-          "type": "string"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "costCategories": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiAzureCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "description": "The account being queried."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "serviceName": {
-          "type": "string",
-          "description": "The service name, such as `Software License`, `Cognosys`, `SendGrid`, `New-Commerce ERP Software License`, etc."
-        },
-        "productName": {
-          "type": "string",
-          "description": "The product code for an Azure service, such as `Dsv4 Series Windows VM`, `CentOS 7.6`, etc."
-        },
-        "region": {
-          "type": "string",
-          "description": "The region of lineitem, if applicable."
-        },
-        "chargeType": {
-          "type": "string",
-          "description": "The charge type of lineitem, if applicable. Such as `New`, `CycleCharge`, `Prorate fees when cancel`, etc."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of lineitem, if applicable."
-        },
-        "billableQuantity": {
-          "type": "number",
-          "format": "double",
-          "description": "The billable quantity of lineitem, if applicable."
-        },
-        "effectiveUnitPrice": {
-          "type": "number",
-          "format": "double",
-          "description": "The effective unit price of lineitem, if applicable."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The true cost (calculated) for this lineitem."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The base currency for `cost`."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
-        },
-        "targetCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `cost`."
-        },
-        "targetCurrency": {
-          "type": "string",
-          "description": "The currency set by `toCurrency`."
-        },
-        "timeInterval": {
-          "type": "string",
-          "description": "The time interval of lineitem, if applicable. Format is `yyyy-MM-ddThh:MM:ssZ/yyyy-mm-ddTHH:mm:ssZ` (for example 2020-09-16T00:00:00Z/2021-09-24T00:00:00Z)."
-        },
-        "billingType": {
-          "type": "string",
-          "description": "The billing type of lineitem, if applicable. Such as `MARKETPLACE`, `UPFRONT`, `Refund`, `Credit` and `OTHERS`."
-        },
-        "alternateId": {
-          "type": "string",
-          "description": "The alternate ID of lineitem, if applicable."
-        },
-        "domainName": {
-          "type": "string",
-          "description": "The domain name of lineitem, if applicable."
-        },
-        "operation": {
-          "type": "string",
-          "description": "The operation of lineitem, if applicable. Such as `Cool LRS Write Operations`, `Cool LRS Data Write`, `Standard Data Transfer Out`, etc."
-        },
-        "usageType": {
-          "type": "string",
-          "description": "The usage type of lineitem, if applicable. Such as `Standard HDD Managed Disks`, `Tables`, `Blob Storage`, etc."
-        },
-        "instanceType": {
-          "type": "string",
-          "description": "The instance type of lineitem, if applicable. Such as `Gateway`, `Standard_B2s`, `Standard_D4s_v3`, etc."
-        },
-        "category": {
-          "type": "string",
-          "description": "The category of lineitem, if applicable. Such as `Software License`, `Marketplace`, `RI`, `Other`, etc."
-        },
-        "subscriptionId": {
-          "type": "string",
-          "description": "The subscription id."
-        },
-        "entitlementId": {
-          "type": "string",
-          "description": "The entitlement id."
-        },
-        "resourceGroup": {
-          "type": "string",
-          "description": "The resource group of the lineitem, if applicable."
-        }
-      }
-    },
-    "apiAzureCostAttribute": {
-      "type": "object",
-      "properties": {
-        "customerId": {
-          "type": "string"
-        },
-        "subscriptionId": {
-          "type": "string"
-        },
-        "entitlementId": {
-          "type": "string"
-        },
-        "groupId": {
-          "type": "string"
-        },
-        "productId": {
-          "type": "string"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "skuId": {
-          "type": "string"
-        },
-        "skuName": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "domainName": {
-          "type": "string"
-        }
-      }
-    },
     "apiBillingGroupForecast": {
       "type": "object",
       "properties": {
@@ -28467,476 +28200,6 @@
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the costtag."
-        }
-      }
-    },
-    "apiCoverAWSRecommendations": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "accountId": {
-          "type": "string"
-        },
-        "accountName": {
-          "type": "string"
-        },
-        "instanceId": {
-          "type": "string"
-        },
-        "instanceName": {
-          "type": "string"
-        },
-        "service": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string"
-        },
-        "costGroup": {
-          "type": "string"
-        },
-        "recommendation": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "estsavings": {
-          "type": "number",
-          "format": "double"
-        },
-        "estcost": {
-          "type": "number",
-          "format": "double"
-        },
-        "estsavingsPercentage": {
-          "type": "number",
-          "format": "double"
-        },
-        "resourceArn": {
-          "type": "string"
-        },
-        "restartNeeded": {
-          "type": "boolean"
-        },
-        "rollbackPossible": {
-          "type": "boolean"
-        },
-        "lastUpdatedAt": {
-          "type": "string"
-        },
-        "recommendationGroup": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "purchaseRIRecommendationDetails": {
-          "$ref": "#/definitions/coverPurchaseRIRecommendationDetails"
-        },
-        "savingsPlanRecommendationDetails": {
-          "$ref": "#/definitions/coverSavingsPlanRecommendationDetails"
-        },
-        "rightSizingRecommendationDetails": {
-          "$ref": "#/definitions/coverRightSizingRecommendationDetails"
-        },
-        "upgradeRecommendationDetails": {
-          "$ref": "#/definitions/coverUpgradeRecommendationDetails"
-        },
-        "migrateRecommendationDetails": {
-          "$ref": "#/definitions/coverMigrateRecommendationDetails"
-        },
-        "stopInstanceRecommendationDetails": {
-          "$ref": "#/definitions/coverStopInstanceRecommendationDetails"
-        },
-        "deleteRecommendationDetails": {
-          "$ref": "#/definitions/coverDeleteRecommendationDetails"
-        },
-        "otherRecommendationDetails": {
-          "$ref": "#/definitions/coverOtherRecommendationDetails"
-        }
-      }
-    },
-    "apiCoverAccount": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "title": "account, subscription, project"
-        }
-      }
-    },
-    "apiCoverAwsOptions": {
-      "type": "object",
-      "properties": {
-        "AccountName": {
-          "type": "string"
-        },
-        "PayerId": {
-          "type": "string"
-        },
-        "RoleArn": {
-          "type": "string"
-        },
-        "ExternalId": {
-          "type": "string"
-        },
-        "StackId": {
-          "type": "string"
-        },
-        "StackRegion": {
-          "type": "string"
-        },
-        "TemplateUrl": {
-          "type": "string"
-        },
-        "BucketName": {
-          "type": "string"
-        },
-        "Prefix": {
-          "type": "string"
-        },
-        "ReportName": {
-          "type": "string"
-        },
-        "registrationStatus": {
-          "$ref": "#/definitions/coverRegistrationStatus"
-        },
-        "Status": {
-          "type": "string"
-        },
-        "RegistrationMethod": {
-          "type": "string",
-          "title": "Valid values for now are: 'console', 'terraform'. default would be 'console'"
-        },
-        "templateVersion": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverAzureOptions": {
-      "type": "object",
-      "properties": {
-        "accountName": {
-          "type": "string"
-        },
-        "azureCustomerId": {
-          "type": "string"
-        },
-        "azurePlanId": {
-          "type": "string"
-        },
-        "serviceAcct": {
-          "type": "string"
-        },
-        "partnerAcct": {
-          "type": "string"
-        },
-        "companyId": {
-          "type": "string"
-        },
-        "payerId": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverBudgetAlert": {
-      "type": "object",
-      "properties": {
-        "threshold": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/coverThreshold"
-          }
-        },
-        "channels": {
-          "$ref": "#/definitions/coverAlertChannels"
-        }
-      }
-    },
-    "apiCoverCategory": {
-      "type": "object",
-      "properties": {
-        "display": {
-          "type": "string"
-        },
-        "query": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverCostCalculation": {
-      "type": "object",
-      "properties": {
-        "estCostAfterDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "estCostBeforeDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "otherDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "savingsPlanDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "estNetUnusedAmortizedCommitments": {
-          "type": "number",
-          "format": "double"
-        },
-        "reservedInstanceDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "usageTypes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiCoverUsageTypes"
-          }
-        }
-      }
-    },
-    "apiCoverCostGroup": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "title": "cost group name"
-        }
-      }
-    },
-    "apiCoverEBSDetails": {
-      "type": "object",
-      "properties": {
-        "currentEBSDetails": {
-          "$ref": "#/definitions/coverCurrentEBSDetails"
-        },
-        "upgradeEBSDetails": {
-          "$ref": "#/definitions/coverEBSRecommendationDetails"
-        }
-      }
-    },
-    "apiCoverEC2Details": {
-      "type": "object",
-      "properties": {
-        "instanceType": {
-          "type": "string"
-        },
-        "tenancy": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverMemoryDBDetails": {
-      "type": "object",
-      "properties": {
-        "family": {
-          "type": "string"
-        },
-        "nodeType": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRDSDetails": {
-      "type": "object",
-      "properties": {
-        "dbEdition": {
-          "type": "string"
-        },
-        "dbEngine": {
-          "type": "string"
-        },
-        "deploymentOptions": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        },
-        "instanceType": {
-          "type": "string"
-        },
-        "licenseModel": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRecommendationDetail": {
-      "type": "object",
-      "properties": {
-        "recommendation": {
-          "type": "string"
-        },
-        "recommendedResourceType": {
-          "type": "string"
-        },
-        "estimatedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "estimatedSavings": {
-          "type": "number",
-          "format": "double"
-        },
-        "region": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRedshiftDetails": {
-      "type": "object",
-      "properties": {
-        "currentGeneration": {
-          "type": "boolean"
-        },
-        "nodeType": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverResult": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRole": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "costgroupsIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiCoverTagData": {
-      "type": "object",
-      "properties": {
-        "tagKey": {
-          "type": "string"
-        },
-        "tagValue": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiCoverUsageTypes": {
-      "type": "object",
-      "properties": {
-        "operation": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "unit": {
-          "type": "string"
-        },
-        "usageAmount": {
-          "type": "number",
-          "format": "double"
-        },
-        "usageType": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverUser": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/coverUserRole"
-          }
-        },
-        "invitedBy": {
-          "type": "object"
-        },
-        "lastUpdated": {
-          "type": "string"
-        },
-        "createdOn": {
-          "type": "string"
-        },
-        "avatar": {
-          "type": "string"
-        },
-        "activated": {
-          "type": "boolean"
-        },
-        "colorTheme": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverUtilizationData": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "format": "float"
         }
       }
     },
@@ -29225,71 +28488,6 @@
         }
       }
     },
-    "apiGcpCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "title": "account data"
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "invoiceMonth": {
-          "type": "string",
-          "description": "The invoice.month of the lineitem, if applicable."
-        },
-        "service": {
-          "type": "string",
-          "description": "The service.Description of the lineitem, if applicable."
-        },
-        "sku": {
-          "type": "string",
-          "description": "The sku.Description of the lineitem, if applicable."
-        },
-        "region": {
-          "type": "string",
-          "description": "The location.region of the lineitem, if applicable."
-        },
-        "zone": {
-          "type": "string",
-          "description": "The location.zone of the lineitem, if applicable."
-        },
-        "creditsType": {
-          "type": "string",
-          "description": "The credits.type of the lineitem, if applicable."
-        },
-        "creditsName": {
-          "type": "string",
-          "description": "The credits.name of the lineitem, if applicable."
-        },
-        "usageUnit": {
-          "type": "string",
-          "description": "The usage.pricing_unit of the lineitem, if applicable."
-        },
-        "usageAmount": {
-          "type": "number",
-          "format": "double",
-          "description": "The usage.amount_in_pricing_units of the lineitem, if applicable."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The currency of the lineitem, if applicable."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The cost of the lineitem, if applicable."
-        }
-      },
-      "description": "see gcp billing data schema details:[https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables]",
-      "title": "Cost for Api Response"
-    },
     "apiGroupCustomDetails": {
       "type": "object",
       "properties": {
@@ -29461,38 +28659,6 @@
         }
       },
       "description": "KeyValueMap resource definition."
-    },
-    "apiLusterLabel": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The label id."
-        },
-        "name": {
-          "type": "string",
-          "description": "The label name."
-        },
-        "color": {
-          "type": "string",
-          "description": "The label color.\nformat: HEX color code ( #FF0000 )."
-        },
-        "description": {
-          "type": "string",
-          "description": "The label description."
-        },
-        "createdAt": {
-          "type": "string",
-          "title": "The label createdAt.\n\"created_at\": \"2023-10-27T10:00:00Z\"",
-          "readOnly": true
-        },
-        "updatedAt": {
-          "type": "string",
-          "title": "The label updatedAt.\n\"updated_at\": \"2023-10-27T10:00:00Z\"",
-          "readOnly": true
-        }
-      },
-      "title": "The message defines the label"
     },
     "apiMSTeamsChannel": {
       "type": "object",
@@ -29784,80 +28950,6 @@
         }
       }
     },
-    "apiRippleAccessGroup": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "billingGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "description": "AccessGroup resource definition."
-    },
-    "apiRippleOrg": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The unique name (or id) of the organization."
-        },
-        "email": {
-          "type": "string",
-          "description": "The registered email of the organization."
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "The metadata (key/value pair) of the organization. If hierarchy is supported, it will be\nseparated by '/', such as 'metakey/subkey=value'. See https://alphauslabs.github.io/blueapi/\nfor the list of supported attributes."
-        }
-      },
-      "description": "Org resource definition."
-    },
-    "apiRippleV1InvoiceServiceDiscounts": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The invoice service discounts id."
-        },
-        "name": {
-          "type": "string",
-          "description": "The invoice service discount name.\nmust be 1-60 characters long."
-        },
-        "description": {
-          "type": "string",
-          "description": "The invoice service discount description.\nMaximum 150 characters long."
-        },
-        "setting": {
-          "$ref": "#/definitions/v1InvoiceServiceDiscountsSetting",
-          "description": "The invoice service discount setting."
-        },
-        "created": {
-          "type": "string",
-          "description": "Timestamp associated with the created.",
-          "readOnly": true
-        },
-        "updated": {
-          "type": "string",
-          "description": "Timestamp associated with the updated.",
-          "readOnly": true
-        }
-      },
-      "description": "InvoiceServiceDiscounts resource definition."
-    },
     "apiSlackChannel": {
       "type": "object",
       "properties": {
@@ -30001,13 +29093,1022 @@
           "title": "total: Includes data on billing totals"
         },
         "settings": {
-          "$ref": "#/definitions/blueapiApiInvoiceSettings",
+          "$ref": "#/definitions/blueapiapiInvoiceSettings",
           "title": "settings: Includes settings related to billing"
         }
       },
       "description": "VendorDetail resource definition."
     },
-    "apiWaveBudget": {
+    "apiawsChartData": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "actualOndemand": {
+          "type": "number",
+          "format": "double"
+        },
+        "actualCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "utilization": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "apiawsCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "The account being queried."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "type": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "productCode": {
+          "type": "string",
+          "description": "The product code for an AWS service, such as `AmazonEC2`, `AmazonRDS`, etc. This can also be an Alphaus-specified custom value."
+        },
+        "serviceCode": {
+          "type": "string",
+          "description": "The CUR service code of the lineitem, if applicable. Sometimes, this is the same as `productCode`, a subset of `productCode`, an Alphaus-specified custom value, or empty."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of the lineitem, if applicable."
+        },
+        "zone": {
+          "type": "string",
+          "description": "The zone of the lineitem, if applicable."
+        },
+        "usageType": {
+          "type": "string",
+          "description": "The CUR usage type of the lineitem, if applicable."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The CUR instance type of the lineitem, if applicable."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The CUR operation of the lineitem, if applicable."
+        },
+        "invoiceId": {
+          "type": "string",
+          "description": "The AWS invoice ID of the lineitem, if applicable."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the lineitem, if applicable."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The resource id of the lineitem, if applicable. At the moment, this is not yet fully supported."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "usage": {
+          "type": "number",
+          "format": "double",
+          "description": "Only set when `description` and/or `resourceId` attributes are specified."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The true cost (calculated) for this lineitem."
+        },
+        "unblendedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "The unblended cost as reflected in the CUR for this lineitem."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The base currency for `cost`, `unblendedCost`, `effectiveCost`, `amortizedCost`. Always set to `USD`, CUR's default currency."
+        },
+        "exchangeRate": {
+          "type": "number",
+          "format": "double",
+          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
+        },
+        "targetCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `cost`."
+        },
+        "targetUnblendedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `unblendedCost`."
+        },
+        "targetCurrency": {
+          "type": "string",
+          "description": "The currency set by `toCurrency`."
+        },
+        "effectiveCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "targetEffectiveCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `effectiveCost`."
+        },
+        "amortizedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "targetAmortizedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `amortizedCost`."
+        },
+        "tagId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Get last update in UNIX time format."
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiKeyValue"
+          },
+          "description": "Various metadata associated with this lineitem."
+        }
+      }
+    },
+    "apiawsCostAttribute": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "serviceCode": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "zone": {
+          "type": "string"
+        },
+        "usageType": {
+          "type": "string"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "invoiceId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiazureCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "The account being queried."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "serviceName": {
+          "type": "string",
+          "description": "The service name, such as `Software License`, `Cognosys`, `SendGrid`, `New-Commerce ERP Software License`, etc."
+        },
+        "productName": {
+          "type": "string",
+          "description": "The product code for an Azure service, such as `Dsv4 Series Windows VM`, `CentOS 7.6`, etc."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of lineitem, if applicable."
+        },
+        "chargeType": {
+          "type": "string",
+          "description": "The charge type of lineitem, if applicable. Such as `New`, `CycleCharge`, `Prorate fees when cancel`, etc."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of lineitem, if applicable."
+        },
+        "billableQuantity": {
+          "type": "number",
+          "format": "double",
+          "description": "The billable quantity of lineitem, if applicable."
+        },
+        "effectiveUnitPrice": {
+          "type": "number",
+          "format": "double",
+          "description": "The effective unit price of lineitem, if applicable."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The true cost (calculated) for this lineitem."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The base currency for `cost`."
+        },
+        "exchangeRate": {
+          "type": "number",
+          "format": "double",
+          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
+        },
+        "targetCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `cost`."
+        },
+        "targetCurrency": {
+          "type": "string",
+          "description": "The currency set by `toCurrency`."
+        },
+        "timeInterval": {
+          "type": "string",
+          "description": "The time interval of lineitem, if applicable. Format is `yyyy-MM-ddThh:MM:ssZ/yyyy-mm-ddTHH:mm:ssZ` (for example 2020-09-16T00:00:00Z/2021-09-24T00:00:00Z)."
+        },
+        "billingType": {
+          "type": "string",
+          "description": "The billing type of lineitem, if applicable. Such as `MARKETPLACE`, `UPFRONT`, `Refund`, `Credit` and `OTHERS`."
+        },
+        "alternateId": {
+          "type": "string",
+          "description": "The alternate ID of lineitem, if applicable."
+        },
+        "domainName": {
+          "type": "string",
+          "description": "The domain name of lineitem, if applicable."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation of lineitem, if applicable. Such as `Cool LRS Write Operations`, `Cool LRS Data Write`, `Standard Data Transfer Out`, etc."
+        },
+        "usageType": {
+          "type": "string",
+          "description": "The usage type of lineitem, if applicable. Such as `Standard HDD Managed Disks`, `Tables`, `Blob Storage`, etc."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The instance type of lineitem, if applicable. Such as `Gateway`, `Standard_B2s`, `Standard_D4s_v3`, etc."
+        },
+        "category": {
+          "type": "string",
+          "description": "The category of lineitem, if applicable. Such as `Software License`, `Marketplace`, `RI`, `Other`, etc."
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "The subscription id."
+        },
+        "entitlementId": {
+          "type": "string",
+          "description": "The entitlement id."
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "The resource group of the lineitem, if applicable."
+        }
+      }
+    },
+    "apiazureCostAttribute": {
+      "type": "object",
+      "properties": {
+        "customerId": {
+          "type": "string"
+        },
+        "subscriptionId": {
+          "type": "string"
+        },
+        "entitlementId": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "productId": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "skuId": {
+          "type": "string"
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "domainName": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverAWSRecommendations": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "string"
+        },
+        "instanceName": {
+          "type": "string"
+        },
+        "service": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "costGroup": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "estsavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "estcost": {
+          "type": "number",
+          "format": "double"
+        },
+        "estsavingsPercentage": {
+          "type": "number",
+          "format": "double"
+        },
+        "resourceArn": {
+          "type": "string"
+        },
+        "restartNeeded": {
+          "type": "boolean"
+        },
+        "rollbackPossible": {
+          "type": "boolean"
+        },
+        "lastUpdatedAt": {
+          "type": "string"
+        },
+        "recommendationGroup": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "purchaseRIRecommendationDetails": {
+          "$ref": "#/definitions/coverPurchaseRIRecommendationDetails"
+        },
+        "savingsPlanRecommendationDetails": {
+          "$ref": "#/definitions/coverSavingsPlanRecommendationDetails"
+        },
+        "rightSizingRecommendationDetails": {
+          "$ref": "#/definitions/coverRightSizingRecommendationDetails"
+        },
+        "upgradeRecommendationDetails": {
+          "$ref": "#/definitions/coverUpgradeRecommendationDetails"
+        },
+        "migrateRecommendationDetails": {
+          "$ref": "#/definitions/coverMigrateRecommendationDetails"
+        },
+        "stopInstanceRecommendationDetails": {
+          "$ref": "#/definitions/coverStopInstanceRecommendationDetails"
+        },
+        "deleteRecommendationDetails": {
+          "$ref": "#/definitions/coverDeleteRecommendationDetails"
+        },
+        "otherRecommendationDetails": {
+          "$ref": "#/definitions/coverOtherRecommendationDetails"
+        }
+      }
+    },
+    "apicoverAccount": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "title": "account, subscription, project"
+        }
+      }
+    },
+    "apicoverAwsOptions": {
+      "type": "object",
+      "properties": {
+        "AccountName": {
+          "type": "string"
+        },
+        "PayerId": {
+          "type": "string"
+        },
+        "RoleArn": {
+          "type": "string"
+        },
+        "ExternalId": {
+          "type": "string"
+        },
+        "StackId": {
+          "type": "string"
+        },
+        "StackRegion": {
+          "type": "string"
+        },
+        "TemplateUrl": {
+          "type": "string"
+        },
+        "BucketName": {
+          "type": "string"
+        },
+        "Prefix": {
+          "type": "string"
+        },
+        "ReportName": {
+          "type": "string"
+        },
+        "registrationStatus": {
+          "$ref": "#/definitions/coverRegistrationStatus"
+        },
+        "Status": {
+          "type": "string"
+        },
+        "RegistrationMethod": {
+          "type": "string",
+          "title": "Valid values for now are: 'console', 'terraform'. default would be 'console'"
+        },
+        "templateVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverAzureOptions": {
+      "type": "object",
+      "properties": {
+        "accountName": {
+          "type": "string"
+        },
+        "azureCustomerId": {
+          "type": "string"
+        },
+        "azurePlanId": {
+          "type": "string"
+        },
+        "serviceAcct": {
+          "type": "string"
+        },
+        "partnerAcct": {
+          "type": "string"
+        },
+        "companyId": {
+          "type": "string"
+        },
+        "payerId": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverBudgetAlert": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverThreshold"
+          }
+        },
+        "channels": {
+          "$ref": "#/definitions/coverAlertChannels"
+        }
+      }
+    },
+    "apicoverCategory": {
+      "type": "object",
+      "properties": {
+        "display": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverCostCalculation": {
+      "type": "object",
+      "properties": {
+        "estCostAfterDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "estCostBeforeDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "otherDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "savingsPlanDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "estNetUnusedAmortizedCommitments": {
+          "type": "number",
+          "format": "double"
+        },
+        "reservedInstanceDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "usageTypes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apicoverUsageTypes"
+          }
+        }
+      }
+    },
+    "apicoverCostGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "title": "cost group name"
+        }
+      }
+    },
+    "apicoverEBSDetails": {
+      "type": "object",
+      "properties": {
+        "currentEBSDetails": {
+          "$ref": "#/definitions/coverCurrentEBSDetails"
+        },
+        "upgradeEBSDetails": {
+          "$ref": "#/definitions/coverEBSRecommendationDetails"
+        }
+      }
+    },
+    "apicoverEC2Details": {
+      "type": "object",
+      "properties": {
+        "instanceType": {
+          "type": "string"
+        },
+        "tenancy": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverMemoryDBDetails": {
+      "type": "object",
+      "properties": {
+        "family": {
+          "type": "string"
+        },
+        "nodeType": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRDSDetails": {
+      "type": "object",
+      "properties": {
+        "dbEdition": {
+          "type": "string"
+        },
+        "dbEngine": {
+          "type": "string"
+        },
+        "deploymentOptions": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "licenseModel": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRecommendationDetail": {
+      "type": "object",
+      "properties": {
+        "recommendation": {
+          "type": "string"
+        },
+        "recommendedResourceType": {
+          "type": "string"
+        },
+        "estimatedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "estimatedSavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "region": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRedshiftDetails": {
+      "type": "object",
+      "properties": {
+        "currentGeneration": {
+          "type": "boolean"
+        },
+        "nodeType": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverResult": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRole": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "costgroupsIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apicoverTagData": {
+      "type": "object",
+      "properties": {
+        "tagKey": {
+          "type": "string"
+        },
+        "tagValue": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apicoverUsageTypes": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "usageAmount": {
+          "type": "number",
+          "format": "double"
+        },
+        "usageType": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverUser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverUserRole"
+          }
+        },
+        "invitedBy": {
+          "type": "object"
+        },
+        "lastUpdated": {
+          "type": "string"
+        },
+        "createdOn": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        },
+        "activated": {
+          "type": "boolean"
+        },
+        "colorTheme": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverUtilizationData": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    "apigcpCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "title": "account data"
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "invoiceMonth": {
+          "type": "string",
+          "description": "The invoice.month of the lineitem, if applicable."
+        },
+        "service": {
+          "type": "string",
+          "description": "The service.Description of the lineitem, if applicable."
+        },
+        "sku": {
+          "type": "string",
+          "description": "The sku.Description of the lineitem, if applicable."
+        },
+        "region": {
+          "type": "string",
+          "description": "The location.region of the lineitem, if applicable."
+        },
+        "zone": {
+          "type": "string",
+          "description": "The location.zone of the lineitem, if applicable."
+        },
+        "creditsType": {
+          "type": "string",
+          "description": "The credits.type of the lineitem, if applicable."
+        },
+        "creditsName": {
+          "type": "string",
+          "description": "The credits.name of the lineitem, if applicable."
+        },
+        "usageUnit": {
+          "type": "string",
+          "description": "The usage.pricing_unit of the lineitem, if applicable."
+        },
+        "usageAmount": {
+          "type": "number",
+          "format": "double",
+          "description": "The usage.amount_in_pricing_units of the lineitem, if applicable."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The currency of the lineitem, if applicable."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The cost of the lineitem, if applicable."
+        }
+      },
+      "description": "see gcp billing data schema details:[https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables]",
+      "title": "Cost for Api Response"
+    },
+    "apilusterLabel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The label id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The label name."
+        },
+        "color": {
+          "type": "string",
+          "description": "The label color.\nformat: HEX color code ( #FF0000 )."
+        },
+        "description": {
+          "type": "string",
+          "description": "The label description."
+        },
+        "createdAt": {
+          "type": "string",
+          "title": "The label createdAt.\n\"created_at\": \"2023-10-27T10:00:00Z\"",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "title": "The label updatedAt.\n\"updated_at\": \"2023-10-27T10:00:00Z\"",
+          "readOnly": true
+        }
+      },
+      "title": "The message defines the label"
+    },
+    "apirippleAccessGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "billingGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "AccessGroup resource definition."
+    },
+    "apirippleOrg": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The unique name (or id) of the organization."
+        },
+        "email": {
+          "type": "string",
+          "description": "The registered email of the organization."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The metadata (key/value pair) of the organization. If hierarchy is supported, it will be\nseparated by '/', such as 'metakey/subkey=value'. See https://alphauslabs.github.io/blueapi/\nfor the list of supported attributes."
+        }
+      },
+      "description": "Org resource definition."
+    },
+    "apiripplev1InvoiceServiceDiscounts": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The invoice service discounts id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The invoice service discount name.\nmust be 1-60 characters long."
+        },
+        "description": {
+          "type": "string",
+          "description": "The invoice service discount description.\nMaximum 150 characters long."
+        },
+        "setting": {
+          "$ref": "#/definitions/v1InvoiceServiceDiscountsSetting",
+          "description": "The invoice service discount setting."
+        },
+        "created": {
+          "type": "string",
+          "description": "Timestamp associated with the created.",
+          "readOnly": true
+        },
+        "updated": {
+          "type": "string",
+          "description": "Timestamp associated with the updated.",
+          "readOnly": true
+        }
+      },
+      "description": "InvoiceServiceDiscounts resource definition."
+    },
+    "apiwaveBudget": {
       "type": "object",
       "properties": {
         "id": {
@@ -30026,7 +30127,7 @@
       },
       "description": "Budget resource definition."
     },
-    "apiWaveBudgetAlert": {
+    "apiwaveBudgetAlert": {
       "type": "object",
       "properties": {
         "id": {
@@ -30038,7 +30139,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiWaveNotification"
+            "$ref": "#/definitions/apiwaveNotification"
           },
           "description": "notification setting."
         },
@@ -30046,14 +30147,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiWaveBudget"
+            "$ref": "#/definitions/apiwaveBudget"
           },
           "description": "budget setting."
         }
       },
       "description": "Budget resource definition."
     },
-    "apiWaveNotification": {
+    "apiwaveNotification": {
       "type": "object",
       "properties": {
         "id": {
@@ -30155,7 +30256,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiAwsChartData"
+            "$ref": "#/definitions/apiawsChartData"
           }
         }
       }
@@ -30831,7 +30932,7 @@
     "azurecspAzureCSPRecommendations": {
       "type": "object"
     },
-    "billingV1AccessGroup": {
+    "billingv1AccessGroup": {
       "type": "object",
       "properties": {
         "accessGroupId": {
@@ -30850,14 +30951,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/billingV1BillingGroup"
+            "$ref": "#/definitions/billingv1BillingGroup"
           },
           "description": "A list of billing groups contained in the access group."
         }
       },
       "description": "Defines the fields associated with a Wave access group."
     },
-    "billingV1AwsOptions": {
+    "billingv1AwsOptions": {
       "type": "object",
       "properties": {
         "useProFormaCur": {
@@ -30869,7 +30970,7 @@
         }
       }
     },
-    "billingV1AzureOptions": {
+    "billingv1AzureOptions": {
       "type": "object",
       "properties": {
         "resourceGroup": {
@@ -30887,7 +30988,7 @@
       },
       "title": "Optional. Azure-specific options"
     },
-    "billingV1BillingGroup": {
+    "billingv1BillingGroup": {
       "type": "object",
       "properties": {
         "billingInternalId": {
@@ -30926,7 +31027,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "title": "List of all accounts"
         },
@@ -30947,12 +31048,12 @@
           "title": "List of all additionalItems"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingV1AwsOptions",
+          "$ref": "#/definitions/billingv1AwsOptions",
           "title": "AWS-specific options"
         }
       }
     },
-    "billingV1InvoiceSettings": {
+    "billingv1InvoiceSettings": {
       "type": "object",
       "properties": {
         "invoiceNo": {
@@ -31039,7 +31140,7 @@
         }
       }
     },
-    "billingV1Tag": {
+    "billingv1Tag": {
       "type": "object",
       "properties": {
         "key": {
@@ -31058,7 +31159,7 @@
       },
       "title": "Individual tag definition for AddTagsToBillingGroup"
     },
-    "billingV1TagData": {
+    "billingv1TagData": {
       "type": "object",
       "properties": {
         "customerId": {
@@ -31080,7 +31181,7 @@
       },
       "title": "Response for tag request"
     },
-    "blueapiApiAccount": {
+    "blueapiapiAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31113,7 +31214,7 @@
         }
       }
     },
-    "blueapiApiBudget": {
+    "blueapiapiBudget": {
       "type": "object",
       "properties": {
         "id": {
@@ -31132,7 +31233,7 @@
         }
       }
     },
-    "blueapiApiChartData": {
+    "blueapiapiChartData": {
       "type": "object",
       "properties": {
         "date": {
@@ -31159,7 +31260,7 @@
         }
       }
     },
-    "blueapiApiFeeDetails": {
+    "blueapiapiFeeDetails": {
       "type": "object",
       "properties": {
         "name": {
@@ -31175,7 +31276,7 @@
       },
       "description": "FeeDetails resource definition."
     },
-    "blueapiApiInvoiceSettings": {
+    "blueapiapiInvoiceSettings": {
       "type": "object",
       "properties": {
         "address": {
@@ -31228,7 +31329,7 @@
       },
       "description": "InvoiceSettings resource definition."
     },
-    "blueapiApiNotification": {
+    "blueapiapiNotification": {
       "type": "object",
       "properties": {
         "id": {
@@ -31247,11 +31348,11 @@
           "type": "boolean"
         },
         "account": {
-          "$ref": "#/definitions/blueapiApiNotificationAccount"
+          "$ref": "#/definitions/blueapiapiNotificationAccount"
         }
       }
     },
-    "blueapiApiNotificationAccount": {
+    "blueapiapiNotificationAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31262,7 +31363,7 @@
         }
       }
     },
-    "blueapiApiRole": {
+    "blueapiapiRole": {
       "type": "object",
       "properties": {
         "name": {
@@ -31286,7 +31387,7 @@
         }
       }
     },
-    "blueapiApiUser": {
+    "blueapiapiUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -31306,7 +31407,7 @@
         }
       }
     },
-    "blueapiApiUtilizationData": {
+    "blueapiapiUtilizationData": {
       "type": "object",
       "properties": {
         "id": {
@@ -31316,12 +31417,12 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiChartData"
+            "$ref": "#/definitions/blueapiapiChartData"
           }
         }
       }
     },
-    "blueapiBillingV1InvoiceServiceDiscounts": {
+    "blueapibillingv1InvoiceServiceDiscounts": {
       "type": "object",
       "properties": {
         "id": {
@@ -31347,7 +31448,7 @@
       },
       "description": "Streaming response message for the InvoiceServiceDiscounts rpc."
     },
-    "blueapiBillingV1ListExchangeRatesResponse": {
+    "blueapibillingv1ListExchangeRatesResponse": {
       "type": "object",
       "properties": {
         "month": {
@@ -31373,22 +31474,22 @@
       },
       "description": "Response message for the ListExchangeRates rpc."
     },
-    "blueapiCostV1CostItem": {
+    "blueapicostv1CostItem": {
       "type": "object",
       "properties": {
         "aws": {
-          "$ref": "#/definitions/apiAwsCost"
+          "$ref": "#/definitions/apiawsCost"
         },
         "gcp": {
-          "$ref": "#/definitions/apiGcpCost"
+          "$ref": "#/definitions/apigcpCost"
         },
         "azure": {
-          "$ref": "#/definitions/apiAzureCost"
+          "$ref": "#/definitions/apiazureCost"
         }
       },
       "description": "Response message wrapper for cloud costs."
     },
-    "blueapiCoverV1CostItem": {
+    "blueapicoverv1CostItem": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31471,15 +31572,15 @@
       },
       "description": "Response message wrapper for cloud costs."
     },
-    "blueapiCoverV1GetUserResponse": {
+    "blueapicoverv1GetUserResponse": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiCoverUser"
+          "$ref": "#/definitions/apicoverUser"
         }
       }
     },
-    "blueapiCoverV1ListExchangeRatesResponse": {
+    "blueapicoverv1ListExchangeRatesResponse": {
       "type": "object",
       "properties": {
         "orgId": {
@@ -31495,7 +31596,7 @@
       },
       "title": "Response message for ListExchangeRates"
     },
-    "blueapiCoverV1Resource": {
+    "blueapicoverv1Resource": {
       "type": "object",
       "properties": {
         "date": {
@@ -31541,7 +31642,7 @@
         }
       }
     },
-    "blueapiFlowV1DailyUtilization": {
+    "blueapiflowv1DailyUtilization": {
       "type": "object",
       "properties": {
         "currentDate": {
@@ -31556,7 +31657,7 @@
       },
       "description": "Daily utilization data for a specific date range."
     },
-    "blueapiFlowV1GetInfoResponse": {
+    "blueapiflowv1GetInfoResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31565,7 +31666,7 @@
       },
       "description": "Response message for the Flow.GetInfo rpc."
     },
-    "blueapiGcV1Resource": {
+    "blueapigcv1Resource": {
       "type": "object",
       "properties": {
         "id": {
@@ -31705,7 +31806,7 @@
         }
       }
     },
-    "blueapiOrgV1CreateOrgRequest": {
+    "blueapiorgv1CreateOrgRequest": {
       "type": "object",
       "properties": {
         "email": {
@@ -31751,11 +31852,11 @@
       },
       "description": "Request message for the Organization.CreateOrg rpc."
     },
-    "blueapiOrgV1CreateOrgResponse": {
+    "blueapiorgv1CreateOrgResponse": {
       "type": "object",
       "properties": {
         "org": {
-          "$ref": "#/definitions/apiRippleOrg"
+          "$ref": "#/definitions/apirippleOrg"
         },
         "password": {
           "type": "string"
@@ -31763,7 +31864,7 @@
       },
       "description": "Response message for the Organization.CreateOrg rpc."
     },
-    "blueapiPricingV1GetInfoResponse": {
+    "blueapipricingv1GetInfoResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31772,7 +31873,7 @@
       },
       "description": "Response message for the Pricing.GetInfo rpc."
     },
-    "blueapiPrismV1TestResponse": {
+    "blueapiprismv1TestResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31780,7 +31881,7 @@
         }
       }
     },
-    "blueapiVortexV1CreateOrgRequest": {
+    "blueapivortexv1CreateOrgRequest": {
       "type": "object",
       "properties": {
         "name": {
@@ -31791,7 +31892,7 @@
         }
       }
     },
-    "blueapiVortexV1CreateOrgResponse": {
+    "blueapivortexv1CreateOrgResponse": {
       "type": "object",
       "properties": {
         "orgId": {
@@ -31805,7 +31906,7 @@
         }
       }
     },
-    "blueapiVortexV1GetUserResponse": {
+    "blueapivortexv1GetUserResponse": {
       "type": "object",
       "properties": {
         "id": {
@@ -31822,7 +31923,7 @@
         }
       }
     },
-    "blueapiVortexV1TestResponse": {
+    "blueapivortexv1TestResponse": {
       "type": "object",
       "properties": {
         "message": {
@@ -31831,7 +31932,7 @@
       },
       "title": "Test only"
     },
-    "costV1CostAttribute": {
+    "costv1CostAttribute": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31848,7 +31949,7 @@
         }
       }
     },
-    "costV1ListCostFilters": {
+    "costv1ListCostFilters": {
       "type": "object",
       "properties": {
         "filterId": {
@@ -32133,7 +32234,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverBudgetAlert"
+            "$ref": "#/definitions/apicoverBudgetAlert"
           },
           "title": "threshold(s) and its respective channel(s) to alert"
         },
@@ -32290,7 +32391,7 @@
           "type": "string"
         },
         "costgroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "startDate": {
           "type": "string"
@@ -32557,7 +32658,7 @@
           "format": "double"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -32596,35 +32697,35 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "eC2DiskUtilization": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "eC2MemoryUtilization": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "networkTrafficData": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "otherDetails": {
           "$ref": "#/definitions/CurrentEC2DetailsOtherDetails"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -32718,7 +32819,7 @@
           "format": "double"
         },
         "EstcostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -32750,7 +32851,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33448,10 +33549,10 @@
           "$ref": "#/definitions/coverEC2UpgadeDetails"
         },
         "currentCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         },
         "estCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33540,7 +33641,7 @@
       "type": "object",
       "properties": {
         "ec2Options": {
-          "$ref": "#/definitions/apiCoverEC2Details"
+          "$ref": "#/definitions/apicoverEC2Details"
         },
         "elasticCacheOptions": {
           "$ref": "#/definitions/coverElasticCacheDetails"
@@ -33549,13 +33650,13 @@
           "$ref": "#/definitions/coverESDetails"
         },
         "rdsOptions": {
-          "$ref": "#/definitions/apiCoverRDSDetails"
+          "$ref": "#/definitions/apicoverRDSDetails"
         },
         "redshiftOptions": {
-          "$ref": "#/definitions/apiCoverRedshiftDetails"
+          "$ref": "#/definitions/apicoverRedshiftDetails"
         },
         "memoryDbOptions": {
-          "$ref": "#/definitions/apiCoverMemoryDBDetails"
+          "$ref": "#/definitions/apicoverMemoryDBDetails"
         },
         "recommendedNormalizedUnits": {
           "type": "integer",
@@ -33614,7 +33715,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         }
       }
@@ -33626,7 +33727,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33660,7 +33761,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33779,7 +33880,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverRecommendationDetail"
+            "$ref": "#/definitions/apicoverRecommendationDetail"
           }
         },
         "currentCost": {
@@ -33830,7 +33931,7 @@
           "format": "int32"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -34076,7 +34177,7 @@
           "$ref": "#/definitions/coverLambdaRightSizingRecommendationDetails"
         },
         "ebsRightSizingRecommendationDetails": {
-          "$ref": "#/definitions/apiCoverEBSDetails"
+          "$ref": "#/definitions/apicoverEBSDetails"
         },
         "ecsRightSizingRecommendationDetails": {
           "$ref": "#/definitions/coverEcsRightSizingRecommendationDetails"
@@ -34493,14 +34594,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "netWorkIO": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         }
       }
@@ -34686,10 +34787,10 @@
           "$ref": "#/definitions/coverEC2UpgadeDetails"
         },
         "currentCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         },
         "estimatedCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -34700,7 +34801,7 @@
           "$ref": "#/definitions/coverUpgradeEC2Details"
         },
         "upgradeEBSDetails": {
-          "$ref": "#/definitions/apiCoverEBSDetails"
+          "$ref": "#/definitions/apicoverEBSDetails"
         },
         "upgradeRDSDetails": {
           "$ref": "#/definitions/coverRDSUpgradeDetails"
@@ -34831,81 +34932,6 @@
           }
         }
       }
-    },
-    "coverV1FeeDetails": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "orgId": {
-          "type": "string"
-        },
-        "vendor": {
-          "type": "string"
-        },
-        "account": {
-          "type": "string"
-        },
-        "month": {
-          "type": "string"
-        },
-        "lineType": {
-          "type": "string"
-        },
-        "feeType": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "started": {
-          "type": "string"
-        },
-        "timeInterval": {
-          "type": "string"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "currency": {
-          "type": "string"
-        },
-        "splitStatus": {
-          "type": "string"
-        },
-        "isAllocated": {
-          "type": "boolean"
-        },
-        "isApplied": {
-          "type": "boolean"
-        },
-        "unblendedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "sourceFee": {
-          "type": "string"
-        },
-        "lastUpdate": {
-          "type": "string"
-        }
-      },
-      "description": "Response message for GetFeeDetails, CreateFeeReallocation rpc."
-    },
-    "coverV1Status": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "IN_PROGRESS",
-        "SUCCESS",
-        "FAILED"
-      ],
-      "default": "PENDING",
-      "title": "Status of upload file"
     },
     "coverViewData": {
       "type": "object",
@@ -35042,7 +35068,82 @@
         }
       }
     },
-    "flowV1SavingsPlanDetailsPurchase": {
+    "coverv1FeeDetails": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "orgId": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "account": {
+          "type": "string"
+        },
+        "month": {
+          "type": "string"
+        },
+        "lineType": {
+          "type": "string"
+        },
+        "feeType": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "started": {
+          "type": "string"
+        },
+        "timeInterval": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "currency": {
+          "type": "string"
+        },
+        "splitStatus": {
+          "type": "string"
+        },
+        "isAllocated": {
+          "type": "boolean"
+        },
+        "isApplied": {
+          "type": "boolean"
+        },
+        "unblendedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "sourceFee": {
+          "type": "string"
+        },
+        "lastUpdate": {
+          "type": "string"
+        }
+      },
+      "description": "Response message for GetFeeDetails, CreateFeeReallocation rpc."
+    },
+    "coverv1Status": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "FAILED"
+      ],
+      "default": "PENDING",
+      "title": "Status of upload file"
+    },
+    "flowv1SavingsPlanDetailsPurchase": {
       "type": "object",
       "properties": {
         "payerId": {
@@ -35092,7 +35193,7 @@
       },
       "title": "Savings plan details to be purchased"
     },
-    "flowV1SavingsPlanRecommendation": {
+    "flowv1SavingsPlanRecommendation": {
       "type": "object",
       "properties": {
         "payerId": {
@@ -35142,20 +35243,6 @@
       },
       "title": "Savings plan recommendation details"
     },
-    "gcV1Org": {
-      "type": "object",
-      "properties": {
-        "orgId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        }
-      }
-    },
     "gcpGCPRecommendations": {
       "type": "object",
       "properties": {
@@ -35188,7 +35275,21 @@
         }
       }
     },
-    "googleRpcStatus": {
+    "gcv1Org": {
+      "type": "object",
+      "properties": {
+        "orgId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "googlerpcStatus": {
       "type": "object",
       "properties": {
         "code": {
@@ -35467,11 +35568,11 @@
       "properties": {
         "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
       "additionalProperties": {},
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "protobufNullValue": {
       "type": "string",
@@ -35479,7 +35580,7 @@
         "NULL_VALUE"
       ],
       "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     },
     "protosOperation": {
       "type": "object",
@@ -35497,7 +35598,7 @@
           "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable."
         },
         "error": {
-          "$ref": "#/definitions/googleRpcStatus",
+          "$ref": "#/definitions/googlerpcStatus",
           "description": "The error result of the operation in case of failure or cancellation."
         },
         "response": {
@@ -35506,23 +35607,6 @@
         }
       },
       "description": "This resource represents a long-running operation that is the result of a\nnetwork API call."
-    },
-    "recommendationAwsAWSRecommendations": {
-      "type": "object",
-      "properties": {
-        "costExplorerRecommendations": {
-          "$ref": "#/definitions/awsCostExplorerRecommendations"
-        },
-        "costOptimizationHubRecommendations": {
-          "$ref": "#/definitions/awsCostOptimizationHubRecommendations"
-        },
-        "trustedAdvisorRecommendations": {
-          "$ref": "#/definitions/awsTrustedAdvisorRecommendations"
-        },
-        "resourceArn": {
-          "type": "string"
-        }
-      }
     },
     "recommendationOCTOGeneratedRecommendations": {
       "type": "object",
@@ -35542,7 +35626,7 @@
       "type": "object",
       "properties": {
         "awsRecommendations": {
-          "$ref": "#/definitions/recommendationAwsAWSRecommendations"
+          "$ref": "#/definitions/recommendationawsAWSRecommendations"
         },
         "gcpRecommendations": {
           "$ref": "#/definitions/gcpGCPRecommendations"
@@ -35621,6 +35705,23 @@
         }
       }
     },
+    "recommendationawsAWSRecommendations": {
+      "type": "object",
+      "properties": {
+        "costExplorerRecommendations": {
+          "$ref": "#/definitions/awsCostExplorerRecommendations"
+        },
+        "costOptimizationHubRecommendations": {
+          "$ref": "#/definitions/awsCostOptimizationHubRecommendations"
+        },
+        "trustedAdvisorRecommendations": {
+          "$ref": "#/definitions/awsTrustedAdvisorRecommendations"
+        },
+        "resourceArn": {
+          "type": "string"
+        }
+      }
+    },
     "rippleAssigned": {
       "type": "object",
       "properties": {
@@ -35660,7 +35761,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "A list of accounts."
         },
@@ -35988,7 +36089,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "List of all members under this payer."
         }
@@ -36609,7 +36710,7 @@
           "description": "Account id."
         },
         "serviceDiscounts": {
-          "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts",
+          "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts",
           "description": "service discount infomation."
         }
       },
@@ -37502,14 +37603,14 @@
         },
         "language": {
           "type": "string",
-          "description": "Optional. CSV header language: \"en\" or \"ja\". Default: \"en\"."
+          "description": "Optional. CSV header language: \"en\" or \"ja\".\nIf empty, defaults to the MSP or login user's language."
         },
         "queries": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Optional. Report queries to include in the export.\nValid values: \"ri_summary\", \"sp_summary\", \"ri_usageaccount\", \"sp_usageaccount\".\nDefault when empty: all 4 reports are included."
+          "description": "Required. Report queries to include in the export. Must contain at least 1 value.\nValid values: \"ri_summary\", \"sp_summary\", \"ri_usageaccount\", \"sp_usageaccount\"."
         },
         "columns": {
           "type": "array",
@@ -37526,7 +37627,10 @@
           "description": "Optional. Per-report column overrides.\nKeys must be valid query names (ri_summary, sp_summary, ri_usageaccount, sp_usageaccount)."
         }
       },
-      "description": "AWS RI/SP export options for ExportReport."
+      "description": "AWS RI/SP export options for ExportReport.",
+      "required": [
+        "queries"
+      ]
     },
     "v1AzureAccount": {
       "type": "object",
@@ -38225,7 +38329,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Lsit of accountId."
         },
@@ -39472,10 +39576,10 @@
       "type": "object",
       "properties": {
         "aws": {
-          "$ref": "#/definitions/apiAwsCostAttribute"
+          "$ref": "#/definitions/apiawsCostAttribute"
         },
         "azure": {
-          "$ref": "#/definitions/apiAzureCostAttribute"
+          "$ref": "#/definitions/apiazureCostAttribute"
         }
       },
       "description": "Response message for the Cost.ReadCostAttributes rpc."
@@ -39910,7 +40014,7 @@
           "title": "Invoice settings"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingV1AwsOptions",
+          "$ref": "#/definitions/billingv1AwsOptions",
           "title": "Optional. AWS-specific options"
         },
         "city": {
@@ -39956,7 +40060,7 @@
           "title": "Optional. Custom fields to add to the billing group"
         },
         "azureOptions": {
-          "$ref": "#/definitions/billingV1AzureOptions"
+          "$ref": "#/definitions/billingv1AzureOptions"
         }
       },
       "description": "Request message for the CreateBillingGroupMerged rpc."
@@ -40025,7 +40129,7 @@
           "title": "Invoice settings"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingV1AwsOptions",
+          "$ref": "#/definitions/billingv1AwsOptions",
           "title": "Optional. AWS-specific options"
         },
         "city": {
@@ -40332,7 +40436,7 @@
           "title": "Optional. Description of the forecast"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup",
+          "$ref": "#/definitions/apicoverCostGroup",
           "title": "Required. Cost Group Id and Name"
         },
         "pastActualCostRange": {
@@ -40368,7 +40472,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -40422,6 +40526,62 @@
         }
       },
       "title": "Response message for CreateCostGroup"
+    },
+    "v1CreateCustomCommitmentPlanRequest": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Required. The cloud provider. Acceptable values: \"aws\", \"azure\", \"gcp\"."
+        },
+        "startDate": {
+          "type": "string",
+          "description": "Required. ISO 8601 lookback window start timestamp (e.g. \"2026-04-09T02:43:39.717Z\")."
+        },
+        "endDate": {
+          "type": "string",
+          "description": "Required. ISO 8601 lookback window end timestamp (e.g. \"2026-04-16T02:43:39.717Z\")."
+        },
+        "segmentId": {
+          "type": "string",
+          "description": "Required. The segment ID to scope the plan to."
+        },
+        "status": {
+          "type": "string",
+          "description": "Plan status. Use \"draft\" to save without submitting.\nAcceptable values: \"draft\", \"submitted\"."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional. Human-readable description for the plan."
+        },
+        "name": {
+          "type": "string",
+          "description": "Required. Human-readable name for the plan."
+        },
+        "includedContractSpecs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ContractSpec"
+          },
+          "description": "List of contract specifications to include in the plan.\nEach entry selects a commitment category, term, payment option, and optional properties.\n\nAcceptable commitment_type values:\n  \"aws/AmazonEC2\", \"aws/AmazonRDS\", \"aws/AmazonElastiCache\",\n  \"aws/savingsplan/Compute\", \"aws/savingsplan/EC2Instance\", \"aws/savingsplan/Database\"\n\nAcceptable term values:\n  \"thirty_day_gris\"  - 30-day Archera Insured (leased: true)\n  \"one_year_gris\"    - 1-year Archera Insured (leased: true)\n  \"one_year\"         - 1-year Native Uninsured (leased: false)\n  \"three_year\"       - 3-year Native Uninsured (leased: false)\n\nAcceptable payment_option values:\n  \"no_upfront\", \"partial_upfront\", \"all_upfront\"\n  Note: \"partial_upfront\" and \"all_upfront\" are not available for 30-day terms.\n\nAcceptable properties keys:\n  \"leased\" (bool)          - true for Archera Insured terms, false for Native terms.\n  \"offering_class\" (string) - only for \"aws/AmazonEC2\"; \"convertible\" or \"standard\"."
+        },
+        "includedContractTerms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of contract term keys included in the plan.\nAcceptable values: \"thirty_day_gris\", \"one_year_gris\", \"one_year\", \"three_year\"."
+        },
+        "resourceIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Specific resource IDs to pin the plan to selected infrastructure resources.\nWhen populated, the server returns plan_type \"infrastructure\"; omit for a top-down\n\"purchase\" plan. IDs are composite strings in the format\n\"{resource_id}|{catalog_sku_org_id}|{catalog_sku_id}\" as returned by ListReservableResources."
+        }
+      },
+      "description": "CreateCustomCommitmentPlanRequest creates a new top-down custom commitment plan."
     },
     "v1CreateCustomFieldRequest": {
       "type": "object",
@@ -40821,7 +40981,7 @@
           "title": "Required"
         },
         "account": {
-          "$ref": "#/definitions/adminV1NotificationAccount",
+          "$ref": "#/definitions/adminv1NotificationAccount",
           "description": "Optional. only available Wave(Pro)."
         }
       },
@@ -41486,11 +41646,11 @@
           "title": "GCP Options"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apiCoverAzureOptions",
+          "$ref": "#/definitions/apicoverAzureOptions",
           "title": "Azure Options"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apiCoverAwsOptions"
+          "$ref": "#/definitions/apicoverAwsOptions"
         },
         "accountType": {
           "type": "string",
@@ -41747,6 +41907,30 @@
         },
         "coverageId": {
           "type": "string"
+        },
+        "monthlyAfterCost": {
+          "type": "number",
+          "format": "double",
+          "title": "Monthly cost breakdowns (returned by CreateCustomCommitmentPlan and related endpoints)"
+        },
+        "monthlyAmortizedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "monthlyBeforeCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "monthlyFee": {
+          "type": "number",
+          "format": "double"
+        },
+        "allTerms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "All term keys present across the plan's line items."
         }
       }
     },
@@ -42147,6 +42331,31 @@
       },
       "description": "Response message for the ExportBillingGroupCsv rpc."
     },
+    "v1ExportReportRequest": {
+      "type": "object",
+      "properties": {
+        "month": {
+          "type": "string",
+          "description": "Required. Billing month in YYYY-MM format."
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Optional. Cloud vendor.\nAccepted values: \"aws\", \"gcp\", \"azure\".\nIf empty, defaults to \"aws\" for backward compatibility."
+        },
+        "notificationChannelIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Notification channel IDs to deliver the report.\nIf empty, the MSP default notification channel configured in DynamoDB is used."
+        },
+        "awsOptions": {
+          "$ref": "#/definitions/v1AwsRispExportOptions",
+          "description": "Optional. Valid only for the `aws` vendor. AWS RI/SP export options.\n\nFuture vendor-specific options follow the same pattern (e.g. gcp_options, azure_options)."
+        }
+      },
+      "description": "Request message for ExportReport."
+    },
     "v1ExportReportResponse": {
       "type": "object",
       "properties": {
@@ -42333,7 +42542,7 @@
       "type": "object",
       "properties": {
         "accessGroup": {
-          "$ref": "#/definitions/billingV1AccessGroup"
+          "$ref": "#/definitions/billingv1AccessGroup"
         }
       },
       "description": "Response message for the Billing.GetAccessGroup rpc."
@@ -42371,7 +42580,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiApiBudget"
+          "$ref": "#/definitions/blueapiapiBudget"
         }
       },
       "title": "Response message for GetAccountBudget"
@@ -42442,7 +42651,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverTagData"
+            "$ref": "#/definitions/apicoverTagData"
           }
         }
       },
@@ -42478,6 +42687,18 @@
         "recommendationSummary": {
           "type": "string",
           "title": "Format: JSON String"
+        }
+      }
+    },
+    "v1GetAvailableCommitmentTypesResponse": {
+      "type": "object",
+      "properties": {
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of available commitment type identifiers for the requested provider.\nExample values: \"aws/AmazonEC2\", \"aws/AmazonRDS\", \"aws/AmazonElastiCache\",\n\"aws/savingsplan/Compute\", \"aws/savingsplan/EC2Instance\", \"aws/savingsplan/Database\"."
         }
       }
     },
@@ -42594,7 +42815,7 @@
       "type": "object",
       "properties": {
         "billingGroup": {
-          "$ref": "#/definitions/billingV1BillingGroup"
+          "$ref": "#/definitions/billingv1BillingGroup"
         }
       },
       "description": "Response message for the Billing.GetBillingGroup rpc."
@@ -42680,7 +42901,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverCategory"
+            "$ref": "#/definitions/apicoverCategory"
           }
         }
       }
@@ -42732,7 +42953,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Optional. accounts that applied to the CustomizedBillingService　config."
         }
@@ -42832,7 +43053,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/costV1CostAttribute"
+            "$ref": "#/definitions/costv1CostAttribute"
           },
           "description": "The cost attributes."
         }
@@ -42878,7 +43099,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -43009,14 +43230,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverResult"
+            "$ref": "#/definitions/apicoverResult"
           }
         },
         "tagData": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverTagData"
+            "$ref": "#/definitions/apicoverTagData"
           }
         }
       },
@@ -43516,7 +43737,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Optional. accounts that applied to the CustomizedBillingService　config."
         }
@@ -43908,7 +44129,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverRole"
+            "$ref": "#/definitions/apicoverRole"
           }
         }
       }
@@ -44231,7 +44452,7 @@
       "type": "object",
       "properties": {
         "recommendationData": {
-          "$ref": "#/definitions/apiCoverAWSRecommendations"
+          "$ref": "#/definitions/apicoverAWSRecommendations"
         }
       }
     },
@@ -44480,14 +44701,14 @@
       "type": "object",
       "properties": {
         "recommendation": {
-          "$ref": "#/definitions/flowV1SavingsPlanRecommendation",
+          "$ref": "#/definitions/flowv1SavingsPlanRecommendation",
           "title": "Recommendation details"
         },
         "purchases": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/flowV1SavingsPlanDetailsPurchase"
+            "$ref": "#/definitions/flowv1SavingsPlanDetailsPurchase"
           },
           "title": "List of purchase items"
         },
@@ -44600,7 +44821,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverTagData"
+            "$ref": "#/definitions/apicoverTagData"
           }
         }
       },
@@ -44724,7 +44945,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiUtilizationData"
+            "$ref": "#/definitions/blueapiapiUtilizationData"
           }
         }
       },
@@ -44869,7 +45090,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUser"
+            "$ref": "#/definitions/apicoverUser"
           }
         }
       }
@@ -45324,7 +45545,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/costV1ListCostFilters"
+            "$ref": "#/definitions/costv1ListCostFilters"
           }
         }
       },
@@ -45480,21 +45701,21 @@
         "createdVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingV1InvoiceSettings"
+            "$ref": "#/definitions/billingv1InvoiceSettings"
           },
           "title": "setting used in invoice creation"
         },
         "savedVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingV1InvoiceSettings"
+            "$ref": "#/definitions/billingv1InvoiceSettings"
           },
           "title": "saved invoice setting for the month"
         },
         "defaultVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingV1InvoiceSettings"
+            "$ref": "#/definitions/billingv1InvoiceSettings"
           },
           "title": "billinggroup's default invoice setting"
         },
@@ -45603,7 +45824,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiNotification"
+            "$ref": "#/definitions/blueapiapiNotification"
           }
         }
       },
@@ -45816,6 +46037,18 @@
     "v1ListReportSchedulesRequest": {
       "type": "object"
     },
+    "v1ListReservableResourcesResponse": {
+      "type": "object",
+      "properties": {
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ReservableResource"
+          }
+        }
+      }
+    },
     "v1ListResourcesResponse": {
       "type": "object",
       "properties": {
@@ -45823,7 +46056,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiGcV1Resource"
+            "$ref": "#/definitions/blueapigcv1Resource"
           }
         }
       }
@@ -45835,7 +46068,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiRole"
+            "$ref": "#/definitions/blueapiapiRole"
           }
         }
       },
@@ -47468,11 +47701,11 @@
           "title": "GCP Options. Specific for GCP"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apiCoverAzureOptions",
+          "$ref": "#/definitions/apicoverAzureOptions",
           "title": "Azure Options. Specific for Azure"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apiCoverAwsOptions",
+          "$ref": "#/definitions/apicoverAwsOptions",
           "title": "Aws Options. Specific for Aws"
         }
       },
@@ -47591,7 +47824,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiCoverUser"
+          "$ref": "#/definitions/apicoverUser"
         }
       }
     },
@@ -47664,6 +47897,257 @@
           "type": "string"
         }
       }
+    },
+    "v1ReservableResource": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        },
+        "billingAccountId": {
+          "type": "string"
+        },
+        "subAccountId": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string",
+          "description": "Cloud provider string, e.g. \"aws\"."
+        },
+        "providerResourceId": {
+          "type": "string"
+        },
+        "providerService": {
+          "type": "string"
+        },
+        "providerSkuId": {
+          "type": "string"
+        },
+        "isSpot": {
+          "type": "boolean"
+        },
+        "isReservable": {
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Display name (nullable)."
+        },
+        "resourceGroup": {
+          "description": "Resource group (nullable)."
+        },
+        "usageEnd": {
+          "type": "string"
+        },
+        "usageStart": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "providerTags": {
+          "type": "object"
+        },
+        "userTags": {
+          "type": "object"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "string"
+        },
+        "availabilityZone": {
+          "description": "Availability zone (nullable)."
+        },
+        "cacheEngine": {
+          "description": "Cache engine (nullable)."
+        },
+        "catalogSkuId": {
+          "type": "string"
+        },
+        "catalogSkuOrgId": {
+          "type": "string"
+        },
+        "classicNetworkingSupport": {
+          "type": "boolean"
+        },
+        "clockSpeed": {
+          "type": "string"
+        },
+        "commonUsageType": {
+          "type": "string"
+        },
+        "coveredUsage": {
+          "type": "number",
+          "format": "double",
+          "description": "Fraction of usage covered by existing commitments (0.0–1.0)."
+        },
+        "databaseEngine": {
+          "description": "Database engine (nullable)."
+        },
+        "dedicatedEbsThroughput": {
+          "type": "string"
+        },
+        "description": {
+          "description": "Description (nullable)."
+        },
+        "ecu": {
+          "type": "string"
+        },
+        "enhancedNetworkingSupported": {
+          "type": "boolean"
+        },
+        "family": {
+          "type": "string"
+        },
+        "fullRegionName": {
+          "type": "string"
+        },
+        "hasOndemandTerms": {
+          "type": "boolean"
+        },
+        "iconUrl": {
+          "type": "string"
+        },
+        "integrationId": {
+          "type": "string"
+        },
+        "intelAvx2Available": {
+          "type": "boolean"
+        },
+        "intelAvxAvailable": {
+          "type": "boolean"
+        },
+        "intelTurboAvailable": {
+          "type": "boolean"
+        },
+        "io": {
+          "description": "IO descriptor (nullable)."
+        },
+        "isCurrentGeneration": {
+          "type": "boolean"
+        },
+        "isMultiAz": {
+          "description": "Multi-AZ flag (nullable)."
+        },
+        "licenseModel": {
+          "type": "string"
+        },
+        "locationType": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string",
+          "description": "Memory in bytes as a string, e.g. \"11274289152.0\"."
+        },
+        "skuName": {
+          "description": "SKU name (nullable)."
+        },
+        "skuTitle": {
+          "type": "string"
+        },
+        "netCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "netSavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "networkPerformance": {
+          "type": "string"
+        },
+        "normalizationSizeFactor": {
+          "type": "string"
+        },
+        "ondemandCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "ondemandUsageUnit": {
+          "type": "string"
+        },
+        "operatingSystem": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "physicalProcessor": {
+          "type": "string"
+        },
+        "preInstalledSw": {
+          "type": "string"
+        },
+        "priceCurrency": {
+          "type": "string"
+        },
+        "processorArchitecture": {
+          "type": "string"
+        },
+        "processorFeatures": {
+          "type": "string"
+        },
+        "publicationDate": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "service": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "storage": {
+          "type": "string"
+        },
+        "taxType": {
+          "description": "Tax type (nullable)."
+        },
+        "tenancy": {
+          "type": "string"
+        },
+        "uptime": {
+          "type": "number",
+          "format": "double",
+          "description": "Fraction of time the resource was running during the lookback period."
+        },
+        "usageType": {
+          "type": "string"
+        },
+        "vcpu": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "vpcNetworkingSupport": {
+          "type": "boolean"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "instanceTypeFamily": {
+          "type": "string"
+        },
+        "dailyUsages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ResourceDailyUsage"
+          },
+          "description": "Per-day usage breakdown for the requested date range."
+        }
+      },
+      "description": "ReservableResource is a fully-detailed infrastructure resource returned by ListReservableResources.\nIt extends the basic resource shape with usage metrics, daily usage breakdown,\nand hardware/catalog attributes needed for the Reservable Infrastructure view.\n\nComposite ID formatted as\n \"{url_encoded_resource_id}|{url_encoded_catalog_sku_org_id}|{url_encoded_catalog_sku_id}\".\n Each component must be URL/percent-encoded before concatenation so embedded \"|\"\n characters do not break parsing. Consumers must split on \"|\" and URL-decode each part."
     },
     "v1ResetDemoDataRequest": {
       "type": "object"
@@ -47766,7 +48250,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverAccount"
+            "$ref": "#/definitions/apicoverAccount"
           }
         }
       }
@@ -47842,6 +48326,10 @@
         "uptime": {
           "type": "number",
           "format": "double"
+        },
+        "providerUsageType": {
+          "type": "string",
+          "description": "Provider-specific usage type label (e.g. \"BoxUsage:c5n.xlarge\")."
         }
       }
     },
@@ -48672,7 +49160,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/billingV1Tag"
+            "$ref": "#/definitions/billingv1Tag"
           },
           "title": "Tags associated with this customer"
         }
@@ -49016,7 +49504,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -49501,7 +49989,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiCoverUser"
+          "$ref": "#/definitions/apicoverUser"
         }
       }
     },
@@ -49623,7 +50111,7 @@
           "title": "File name"
         },
         "status": {
-          "$ref": "#/definitions/coverV1Status",
+          "$ref": "#/definitions/coverv1Status",
           "title": "Status"
         }
       },
@@ -49717,7 +50205,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiFlowV1DailyUtilization"
+            "$ref": "#/definitions/blueapiflowv1DailyUtilization"
           },
           "title": "Array of daily utilization data for this Savings Plan"
         }


### PR DESCRIPTION
Introduce new RPCs to manage reservable infrastructure resources and custom commitment plans, enhancing the infrastructure capabilities of the service. This includes endpoints for listing reservable resources, retrieving available commitment types, and creating custom commitment plans.