### PR TITLE
feat: add commitment entry rpcs

### DIFF
--- a/gc/v1/gc.proto
+++ b/gc/v1/gc.proto
@@ -61,6 +61,19 @@ service GuaranteedCommitments {
     };
   }
 
+  rpc ListCommitmentEntries(ListCommitmentEntriesRequest) returns (ListCommitmentEntriesResponse) {
+    option (google.api.http) = {
+      get: "/v1/commitments/entries"
+    };
+  }
+
+  rpc UpdateCommitmentEntryStatus(UpdateCommitmentEntryStatusRequest) returns (UpdateCommitmentEntryStatusResponse) {
+    option (google.api.http) = {
+      post: "/v1/commitments/entries/status:update"
+      body: "*"
+    };
+  }
+
   // ####################### METRICS #######################
 
   // WORK-IN-PROGRESS: Do not use. Retrieves key performance metrics for cloud commitments.
@@ -405,6 +418,20 @@ message GetCommitmentsChartRequest {
 message GetCommitmentsUtilizationRequest {
   // Required. The commitment id.
   string commitmentId = 1;
+}
+
+message ListCommitmentEntriesRequest {
+  // Required. Billing period in YYYY-MM format.
+  string billingPeriod = 1;
+  // Optional. Filter by status: "applied" or "pending". Empty returns all.
+  string status = 2;
+}
+
+message UpdateCommitmentEntryStatusRequest {
+  // Required. Entry IDs to update.
+  repeated string ids = 1;
+  // Required. New status: "applied" or "pending".
+  string status = 2;
 }
 
 message GetMetricsRequest {
@@ -1010,6 +1037,41 @@ message CommitmentsUtilizationData {
 
 message CommitmentsUtilizationResponse {
   repeated CommitmentsUtilizationData data = 1;
+}
+
+message CommitmentEntry {
+  string id = 1;
+  string lineItemId = 2;
+  string mspId = 3;
+  string commitmentId = 4;
+  string invoiceId = 5;
+  string contractTerm = 6;
+  double feeRate = 7;
+  double griPremiums = 8;
+  double rebate = 9;
+  double monthlyCommitment = 10;
+  double monthlySavings = 11;
+  double netSavings = 12;
+  double utilization = 13;
+  string type = 14;
+  double amount = 15;
+  string accountId = 16;
+  string billingAccountId = 17;
+  string commitmentDisplayName = 18;
+  string commitmentLeasedName = 19;
+  string provider = 20;
+  string commitmentType = 21;
+  string billingPeriod = 22;
+  string status = 23;
+}
+
+message ListCommitmentEntriesResponse {
+  repeated CommitmentEntry entries = 1;
+}
+
+message UpdateCommitmentEntryStatusResponse {
+  bool success = 1;
+  int32 updated = 2;
 }
 
 message MetricsResponse {

--- a/gc/v1/gc.proto
+++ b/gc/v1/gc.proto
@@ -61,15 +61,17 @@ service GuaranteedCommitments {
     };
   }
 
-  rpc ListCommitmentEntries(ListCommitmentEntriesRequest) returns (ListCommitmentEntriesResponse) {
+    // ####################### INVOICES #######################
+
+  rpc ListInvoiceEntries(ListInvoiceEntriesRequest) returns (ListInvoiceEntriesResponse) {
     option (google.api.http) = {
-      get: "/v1/commitments/entries"
+      get: "/v1/invoices/entries"
     };
   }
 
-  rpc UpdateCommitmentEntryStatus(UpdateCommitmentEntryStatusRequest) returns (UpdateCommitmentEntryStatusResponse) {
+  rpc UpdateInvoiceEntryStatus(UpdateInvoiceEntryStatusRequest) returns (UpdateInvoiceEntryStatusResponse) {
     option (google.api.http) = {
-      post: "/v1/commitments/entries/status:update"
+      post: "/v1/invoices/entries/status:update"
       body: "*"
     };
   }
@@ -420,14 +422,14 @@ message GetCommitmentsUtilizationRequest {
   string commitmentId = 1;
 }
 
-message ListCommitmentEntriesRequest {
+message ListInvoiceEntriesRequest {
   // Required. Billing period in YYYY-MM format.
   string billingPeriod = 1;
   // Optional. Filter by status: "applied" or "pending". Empty returns all.
   string status = 2;
 }
 
-message UpdateCommitmentEntryStatusRequest {
+message UpdateInvoiceEntryStatusRequest {
   // Required. Entry IDs to update.
   repeated string ids = 1;
   // Required. New status: "applied" or "pending".
@@ -1039,7 +1041,7 @@ message CommitmentsUtilizationResponse {
   repeated CommitmentsUtilizationData data = 1;
 }
 
-message CommitmentEntry {
+message InvoiceEntry {
   string id = 1;
   string lineItemId = 2;
   string mspId = 3;
@@ -1065,11 +1067,11 @@ message CommitmentEntry {
   string status = 23;
 }
 
-message ListCommitmentEntriesResponse {
-  repeated CommitmentEntry entries = 1;
+message ListInvoiceEntriesResponse {
+  repeated InvoiceEntry entries = 1;
 }
 
-message UpdateCommitmentEntryStatusResponse {
+message UpdateInvoiceEntryStatusResponse {
   bool success = 1;
   int32 updated = 2;
 }


### PR DESCRIPTION
## Changes

Added two new RPCs to the `GuaranteedCommitments` service:

- **`ListCommitmentEntries`** — `GET /v1/commitments/entries`
  Retrieves commitment entries from Spanner by billing period, with optional
  status filter (`applied`/`pending`). 

- **`UpdateCommitmentEntryStatus`** — `POST /v1/commitments/entries/status:update`
  Batch updates the status of commitment entries by IDs.

New message types:
- `ListCommitmentEntriesRequest`, `ListCommitmentEntriesResponse`
- `UpdateCommitmentEntryStatusRequest`, `UpdateCommitmentEntryStatusResponse`
- `CommitmentEntry` (23 fields matching the `archera_commitment_entries` Spanner table)