### PR TITLE
feat(billing): add CreateCustomFee and ListAdjustmentEntryItems rpcs

### DIFF
--- a/billing/v1/billing.proto
+++ b/billing/v1/billing.proto
@@ -569,7 +569,7 @@ service Billing {
   }
 
   // Creates custom fee entries in the RIPPLE_FEES table.
-  // Used by Archera service to write commitment entries and by DTS to write custom fees directly to the RIPPLE_FEES table. Only available in Ripple.
+  // Used to write Guaranteed Commitment entries and Custom Fee entries directly to the fee table. Only available in Ripple.
   rpc CreateCustomFee(CreateCustomFeeRequest) returns (CreateCustomFeeResponse) {
     option (google.api.http) = {
       post: "/v1/{vendor}/adjustmententries/customfees"
@@ -577,9 +577,9 @@ service Billing {
     };
   }
 
-  // Lists guaranteed commitment entry items for the Guaranteed Commitment Entries UI.
-  // Reads fee entries from the RIPPLE_FEES table filtered by mobingi_type (defaults to "Commitments").
-  // Note: Commitment entries (mobingi_type="Commitments") are excluded from ReadAdjustmentEntries to avoid duplication with the Adjusting Entries UI. Only available in Ripple.
+  // Lists adjustment entry items from the fee table.
+  // Reads fee entries from the RIPPLE_FEES table, optionally filtered by mobingi_type.
+  // Note: Commitment entries (mobingi_type="COMMITMENT") are excluded from ReadAdjustmentEntries to avoid duplication with the Adjusting Entries UI. Only available in Ripple.
   rpc ListAdjustmentEntryItems(ListAdjustmentEntryItemsRequest) returns (stream AdjustmentEntryItem) {
     option (google.api.http) = {
       post: "/v1/{vendor}/adjustmententryitems:read"
@@ -2398,7 +2398,8 @@ message CustomFeeEntry {
   string feeType = 3 [(google.api.field_behavior) = REQUIRED];
 
   // Required. The entry type stored in the mobingi_type column.
-  // Used for filtering and categorization (e.g., "Commitments" for Archera, "Custom" for DTS).
+  // Used for filtering and categorization (e.g., "COMMITMENT" for Guaranteed Commitments, "CUSTOM" for Custom Fees).
+  // Accepted values: UPFRONT, SUPPORT, REGISTRAR, OTHERS, CREDIT, REFUND, COMMITMENT, CUSTOM.
   string mobingiType = 4 [(google.api.field_behavior) = REQUIRED];
 
   // Required. The fee amount (cost). Positive for charges, negative for rebates.
@@ -2423,12 +2424,12 @@ message CustomFeeEntry {
   // Optional. The time interval in ISO 8601 interval format.
   string timeInterval = 11 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. Additional metadata as a JSON string.
-  // For Archera commitment entries, contains: commitment_id, invoice_id,
+  // Optional. Additional metadata as key-value pairs.
+  // For Guaranteed Commitment entries, may contain: commitment_id, invoice_id,
   // contract_term, fee_rate, monthly_commitment, monthly_savings, net_savings,
   // utilization, billing_account_id, commitment_display_name,
   // commitment_leased_name, provider, commitment_type.
-  string meta = 12 [(google.api.field_behavior) = OPTIONAL];
+  map<string, string> meta = 12 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Response message for the Billing.CreateCustomFee rpc.
@@ -2446,7 +2447,7 @@ message ListAdjustmentEntryItemsRequest {
   string month = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. Filter by entry type (mobingi_type column).
-  // Defaults to "Commitments" if empty. Used by the Guaranteed Commitment Entries UI.
+  // If not specified, returns all adjustment entry items.
   string mobingiType = 3 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. Filter by apply status.
@@ -2460,8 +2461,8 @@ message AdjustmentEntryItem {
   // The standard adjustment entry fields (id, account info, entry info, settings).
   api.ripple.v1.AdjustmentEntry entry = 1;
 
-  // Additional metadata as a JSON string.
-  string meta = 2;
+  // Additional metadata as key-value pairs.
+  map<string, string> meta = 2;
 }
 
 //Request message for the Billing.ListAccountResources rpc.

--- a/billing/v1/billing.proto
+++ b/billing/v1/billing.proto
@@ -568,6 +568,25 @@ service Billing {
     };
   }
 
+  // Creates custom fee entries in the RIPPLE_FEES table.
+  // Used by Archera service to write commitment entries and by DTS to write custom fees directly to the RIPPLE_FEES table. Only available in Ripple.
+  rpc CreateCustomFee(CreateCustomFeeRequest) returns (CreateCustomFeeResponse) {
+    option (google.api.http) = {
+      post: "/v1/{vendor}/adjustmententries/customfees"
+      body: "*"
+    };
+  }
+
+  // Lists guaranteed commitment entry items for the Guaranteed Commitment Entries UI.
+  // Reads fee entries from the RIPPLE_FEES table filtered by mobingi_type (defaults to "Commitments").
+  // Note: Commitment entries (mobingi_type="Commitments") are excluded from ReadAdjustmentEntries to avoid duplication with the Adjusting Entries UI. Only available in Ripple.
+  rpc ListAdjustmentEntryItems(ListAdjustmentEntryItemsRequest) returns (stream AdjustmentEntryItem) {
+    option (google.api.http) = {
+      post: "/v1/{vendor}/adjustmententryitems:read"
+      body: "*"
+    };
+  }
+
   // WORK-IN-PROGRESS: Returns all registered accounts that are not associated to any billing groups and accounts found in CUR for the specified month. For Ripple only
   rpc ListAccountResources(ListAccountResourcesRequest) returns (stream ResourceAccount) {
     option (google.api.http) = {
@@ -2352,6 +2371,97 @@ message RestoreAllocateAdjustmentEntryRequest {
 
   // Required. AdjustmentEntry ID.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for the Billing.CreateCustomFee rpc.
+message CreateCustomFeeRequest {
+  // Required. At the moment, only `aws` is supported.
+  string vendor = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The billing month. Format is `yyyymm`.
+  string month = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The fee entries to create.
+  repeated CustomFeeEntry entries = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// A single custom fee entry to write to the adjustments table.
+message CustomFeeEntry {
+  // Required. The linked account ID (customer_id in the fee table sort key).
+  string accountId = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The payer account ID (account_id in the fee table sort key).
+  string payerAccountId = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The fee type for the sort key type segment.
+  // Determines the main Type column value in Adjusting Entries (e.g., "Fee").
+  string feeType = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The entry type stored in the mobingi_type column.
+  // Used for filtering and categorization (e.g., "Commitments" for Archera, "Custom" for DTS).
+  string mobingiType = 4 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The fee amount (cost). Positive for charges, negative for rebates.
+  double amount = 5 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The currency code (e.g., "USD").
+  string currencyCode = 6 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. Human-readable description of the fee.
+  // For commitment entries: e.g., "Guaranteed Compute Savings Plan - Premium".
+  string description = 7 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. The product/service code (e.g., "aws/savingsplan").
+  string productCode = 8 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The product/service display name (e.g., "Compute Savings Plan").
+  string productName = 9 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The usage start time in RFC 3339 format.
+  string usageStart = 10 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The time interval in ISO 8601 interval format.
+  string timeInterval = 11 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Additional metadata as a JSON string.
+  // For Archera commitment entries, contains: commitment_id, invoice_id,
+  // contract_term, fee_rate, monthly_commitment, monthly_savings, net_savings,
+  // utilization, billing_account_id, commitment_display_name,
+  // commitment_leased_name, provider, commitment_type.
+  string meta = 12 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the Billing.CreateCustomFee rpc.
+message CreateCustomFeeResponse {
+  // The number of entries successfully created.
+  int32 created = 1;
+}
+
+// Request message for the Billing.ListAdjustmentEntryItems rpc.
+message ListAdjustmentEntryItemsRequest {
+  // Required. At the moment, only `aws` is supported.
+  string vendor = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The billing month. Format is `yyyymm`.
+  string month = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. Filter by entry type (mobingi_type column).
+  // Defaults to "Commitments" if empty. Used by the Guaranteed Commitment Entries UI.
+  string mobingiType = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Filter by apply status.
+  // "applied" returns entries where apply=true, "pending" returns entries where apply=false.
+  // If empty, returns all entries regardless of status.
+  string status = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// An adjustment entry item with additional metadata for the Guaranteed Commitment Entries UI.
+message AdjustmentEntryItem {
+  // The standard adjustment entry fields (id, account info, entry info, settings).
+  api.ripple.v1.AdjustmentEntry entry = 1;
+
+  // Additional metadata as a JSON string.
+  string meta = 2;
 }
 
 //Request message for the Billing.ListAccountResources rpc.


### PR DESCRIPTION
Adds two new RPCs to billing.proto:

- CreateCustomFee — Writes custom fee entries directly to the RIPPLE_FEES DynamoDB table. Used by Archera service (commitment entries) and DTS (custom fees).
`POST /v1/{vendor}/adjustmententries/customfees`

- ListAdjustmentEntryItems — Lists fee entries filtered by mobingi_type (defaults to "Commitments"), with optional status filter (applied/pending).
`POST /v1/{vendor}/adjustmententryitems:read`

New messages: CreateCustomFeeRequest, CustomFeeEntry, CreateCustomFeeResponse, ListAdjustmentEntryItemsRequest, AdjustmentEntryItem.