### PR TITLE
feat(admin): add product field to ExportAuditLogsRequest

### DIFF
--- a/admin/v1/admin.proto
+++ b/admin/v1/admin.proto
@@ -619,6 +619,9 @@ message ExportAuditLogsRequest {
 
   // Required. The UTC date to end data from. If not set, the first day of the current year will be used. Format: `yyyymmdd`.
   string endTime = 3;
+
+  // Optional. Valid values are 'ripple' and 'wavepro' for now. If empty default is 'ripple'.
+  string product = 4;
 }
 
 // for wave features settings data maping

--- a/openapiv2/apidocs.swagger.json
+++ b/openapiv2/apidocs.swagger.json
@@ -153,7 +153,7 @@
                   "$ref": "#/definitions/v1ListAccountGroupsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListAccountGroupsResponse"
@@ -162,7 +162,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -185,7 +185,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -216,7 +216,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -250,7 +250,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -283,7 +283,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -304,7 +304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -338,7 +338,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -368,7 +368,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -402,7 +402,7 @@
                   "$ref": "#/definitions/v1DefaultCostAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1DefaultCostAccess"
@@ -411,7 +411,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -434,7 +434,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -465,7 +465,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -495,7 +495,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -528,7 +528,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -561,7 +561,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -592,7 +592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -613,7 +613,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -647,7 +647,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -684,7 +684,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -714,7 +714,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -754,7 +754,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -788,7 +788,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -809,7 +809,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -843,7 +843,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -858,13 +858,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiNotification"
+              "$ref": "#/definitions/blueapiapiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -892,13 +892,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiNotification"
+              "$ref": "#/definitions/blueapiapiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -936,7 +936,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -967,13 +967,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiNotification"
+              "$ref": "#/definitions/blueapiapiNotification"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1013,7 +1013,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1042,7 +1042,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1075,7 +1075,7 @@
                   "$ref": "#/definitions/v1Announcement"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Announcement"
@@ -1084,7 +1084,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1116,7 +1116,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1163,7 +1163,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1210,7 +1210,7 @@
                   "$ref": "#/definitions/apiApiClient"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiApiClient"
@@ -1219,7 +1219,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1240,7 +1240,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1275,7 +1275,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1307,7 +1307,7 @@
                   "$ref": "#/definitions/apiGroupRootUser"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiGroupRootUser"
@@ -1316,7 +1316,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1337,7 +1337,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1370,7 +1370,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1400,7 +1400,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1432,7 +1432,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1462,7 +1462,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1501,7 +1501,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1523,7 +1523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1558,7 +1558,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1590,7 +1590,7 @@
                   "$ref": "#/definitions/v1IpFilter"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1IpFilter"
@@ -1599,7 +1599,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1620,7 +1620,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1655,7 +1655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1687,7 +1687,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1726,7 +1726,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1758,7 +1758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1798,7 +1798,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1838,7 +1838,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1872,7 +1872,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1905,7 +1905,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1938,7 +1938,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1971,7 +1971,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -1995,13 +1995,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiRole"
+              "$ref": "#/definitions/blueapiapiRole"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2036,7 +2036,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2067,13 +2067,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiRole"
+              "$ref": "#/definitions/blueapiapiRole"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2120,7 +2120,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2150,7 +2150,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2182,7 +2182,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2213,19 +2213,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiUser"
+                  "$ref": "#/definitions/blueapiapiUser"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiUser"
+              "title": "Stream result of blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2240,13 +2240,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiUser"
+              "$ref": "#/definitions/blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2274,13 +2274,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiUser"
+              "$ref": "#/definitions/blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2310,7 +2310,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2336,13 +2336,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiUser"
+              "$ref": "#/definitions/blueapiapiUser"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2366,7 +2366,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2406,7 +2406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2437,7 +2437,7 @@
                   "$ref": "#/definitions/protosOperation"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of protosOperation"
@@ -2446,7 +2446,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2492,7 +2492,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2523,7 +2523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2556,7 +2556,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2590,13 +2590,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleOrg"
+              "$ref": "#/definitions/apirippleOrg"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2618,7 +2618,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2633,13 +2633,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiOrgV1CreateOrgResponse"
+              "$ref": "#/definitions/blueapiorgv1CreateOrgResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2650,7 +2650,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/blueapiOrgV1CreateOrgRequest"
+              "$ref": "#/definitions/blueapiorgv1CreateOrgRequest"
             }
           }
         ],
@@ -2674,7 +2674,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2709,7 +2709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2744,7 +2744,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2768,7 +2768,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2799,7 +2799,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2816,13 +2816,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiPricingV1GetInfoResponse"
+              "$ref": "#/definitions/blueapipricingv1GetInfoResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2845,7 +2845,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2885,7 +2885,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2914,19 +2914,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/apiRippleAccessGroup"
+                  "$ref": "#/definitions/apirippleAccessGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of apiRippleAccessGroup"
+              "title": "Stream result of apirippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2950,13 +2950,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleAccessGroup"
+              "$ref": "#/definitions/apirippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -2990,7 +2990,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3029,7 +3029,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3053,13 +3053,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleAccessGroup"
+              "$ref": "#/definitions/apirippleAccessGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3100,7 +3100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3134,7 +3134,7 @@
                   "$ref": "#/definitions/v1DataAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1DataAccess"
@@ -3143,7 +3143,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3166,7 +3166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3189,7 +3189,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3234,7 +3234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3279,7 +3279,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3319,7 +3319,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3356,7 +3356,7 @@
                   "$ref": "#/definitions/v1Activity"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Activity"
@@ -3365,7 +3365,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3398,7 +3398,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3429,7 +3429,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3460,7 +3460,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3498,7 +3498,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3537,7 +3537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3571,7 +3571,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3606,7 +3606,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3639,7 +3639,7 @@
                   "$ref": "#/definitions/v1AnomalyAlertData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AnomalyAlertData"
@@ -3648,7 +3648,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3671,7 +3671,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3702,7 +3702,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3733,7 +3733,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3773,7 +3773,7 @@
                   "$ref": "#/definitions/v1GetAlertsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetAlertsResponse"
@@ -3782,7 +3782,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3803,7 +3803,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3836,7 +3836,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3866,7 +3866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3896,7 +3896,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3937,7 +3937,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -3970,7 +3970,7 @@
                   "$ref": "#/definitions/v1DiscountExpiryAlertData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1DiscountExpiryAlertData"
@@ -3979,7 +3979,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4002,7 +4002,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4033,7 +4033,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4064,7 +4064,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4105,7 +4105,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4137,7 +4137,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4168,7 +4168,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4209,7 +4209,7 @@
                   "$ref": "#/definitions/v1BudgetAlerts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1BudgetAlerts"
@@ -4218,7 +4218,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4252,7 +4252,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4261,7 +4261,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4295,7 +4295,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4304,7 +4304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4338,7 +4338,7 @@
                   "$ref": "#/definitions/v1AccountUsageDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountUsageDetails"
@@ -4347,7 +4347,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4378,19 +4378,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverV1FeeDetails"
+                  "$ref": "#/definitions/coverv1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of coverV1FeeDetails"
+              "title": "Stream result of coverv1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4421,19 +4421,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverV1FeeDetails"
+                  "$ref": "#/definitions/coverv1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of coverV1FeeDetails"
+              "title": "Stream result of coverv1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4464,19 +4464,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/coverV1FeeDetails"
+                  "$ref": "#/definitions/coverv1FeeDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of coverV1FeeDetails"
+              "title": "Stream result of coverv1FeeDetails"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4510,7 +4510,7 @@
                   "$ref": "#/definitions/v1FeeItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1FeeItem"
@@ -4519,7 +4519,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4553,7 +4553,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4562,7 +4562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4596,7 +4596,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4605,7 +4605,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4639,7 +4639,7 @@
                   "$ref": "#/definitions/v1SavingsDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1SavingsDetails"
@@ -4648,7 +4648,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4682,7 +4682,7 @@
                   "$ref": "#/definitions/v1AllocationItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AllocationItem"
@@ -4691,7 +4691,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4725,7 +4725,7 @@
                   "$ref": "#/definitions/v1CostAllocatorDetails"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CostAllocatorDetails"
@@ -4734,7 +4734,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4755,7 +4755,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4789,7 +4789,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4820,7 +4820,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4858,7 +4858,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4888,7 +4888,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4927,7 +4927,7 @@
                   "$ref": "#/definitions/v1AnomalyData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AnomalyData"
@@ -4936,7 +4936,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -4968,7 +4968,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5007,7 +5007,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5057,19 +5057,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCoverV1Resource"
+                  "$ref": "#/definitions/blueapicoverv1Resource"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCoverV1Resource"
+              "title": "Stream result of blueapicoverv1Resource"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5103,7 +5103,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5136,7 +5136,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5166,7 +5166,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5200,7 +5200,7 @@
                   "$ref": "#/definitions/v1AccountAccess"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountAccess"
@@ -5209,7 +5209,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5243,7 +5243,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5277,7 +5277,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5311,7 +5311,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5341,7 +5341,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5374,7 +5374,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5408,7 +5408,7 @@
                   "$ref": "#/definitions/v1AwsDailyRunHistory"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AwsDailyRunHistory"
@@ -5417,7 +5417,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5451,7 +5451,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5472,7 +5472,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5506,7 +5506,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5527,7 +5527,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5561,7 +5561,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5593,7 +5593,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5633,7 +5633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5667,7 +5667,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5700,7 +5700,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5724,7 +5724,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5758,7 +5758,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5792,7 +5792,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5826,7 +5826,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5865,7 +5865,7 @@
                   "$ref": "#/definitions/v1ListBillingGroupCustomFieldResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListBillingGroupCustomFieldResponse"
@@ -5874,7 +5874,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5907,7 +5907,7 @@
                   "$ref": "#/definitions/v1GetBillingGroupAnnouncementsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetBillingGroupAnnouncementsResponse"
@@ -5916,7 +5916,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5949,7 +5949,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -5983,7 +5983,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6014,7 +6014,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6052,7 +6052,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6100,7 +6100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6148,7 +6148,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6188,7 +6188,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6228,7 +6228,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6268,7 +6268,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6308,7 +6308,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6348,7 +6348,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6388,7 +6388,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6424,19 +6424,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/billingV1BillingGroup"
+                  "$ref": "#/definitions/billingv1BillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of billingV1BillingGroup"
+              "title": "Stream result of billingv1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6488,13 +6488,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/billingV1BillingGroup"
+              "$ref": "#/definitions/billingv1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6528,7 +6528,7 @@
                   "$ref": "#/definitions/v1AbcBillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AbcBillingGroup"
@@ -6537,7 +6537,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6569,7 +6569,7 @@
                   "$ref": "#/definitions/v1AbcAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AbcAccount"
@@ -6578,7 +6578,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6617,7 +6617,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6650,7 +6650,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6680,7 +6680,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6710,7 +6710,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6750,7 +6750,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6790,7 +6790,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6821,7 +6821,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6861,7 +6861,7 @@
                   "$ref": "#/definitions/v1AccountInvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountInvoiceServiceDiscounts"
@@ -6870,7 +6870,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6903,7 +6903,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6943,7 +6943,7 @@
                   "$ref": "#/definitions/v1ChildBillingGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ChildBillingGroup"
@@ -6952,7 +6952,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -6985,7 +6985,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7022,7 +7022,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7080,7 +7080,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7111,7 +7111,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7138,13 +7138,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/billingV1BillingGroup"
+              "$ref": "#/definitions/billingv1BillingGroup"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7178,7 +7178,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7217,7 +7217,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7257,7 +7257,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7290,7 +7290,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7323,7 +7323,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7357,7 +7357,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7454,7 +7454,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7487,7 +7487,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7517,7 +7517,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7547,7 +7547,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7587,7 +7587,7 @@
                   "$ref": "#/definitions/v1ListBudgetsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListBudgetsResponse"
@@ -7596,7 +7596,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7629,7 +7629,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7660,7 +7660,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7693,7 +7693,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7723,7 +7723,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7753,7 +7753,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7793,7 +7793,7 @@
                   "$ref": "#/definitions/v1GetChannelsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetChannelsResponse"
@@ -7802,7 +7802,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7835,7 +7835,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7869,7 +7869,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7892,7 +7892,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7931,7 +7931,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7954,7 +7954,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -7986,7 +7986,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8020,7 +8020,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8052,7 +8052,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8084,7 +8084,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8124,7 +8124,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8155,7 +8155,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8188,7 +8188,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8220,7 +8220,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8271,7 +8271,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8302,7 +8302,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8329,13 +8329,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiLusterLabel"
+              "$ref": "#/definitions/apilusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8370,7 +8370,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8394,13 +8394,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiLusterLabel"
+              "$ref": "#/definitions/apilusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8437,19 +8437,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/apiLusterLabel"
+                  "$ref": "#/definitions/apilusterLabel"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of apiLusterLabel"
+              "title": "Stream result of apilusterLabel"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8483,7 +8483,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8523,7 +8523,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8571,7 +8571,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8615,7 +8615,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8669,7 +8669,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8714,7 +8714,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8751,7 +8751,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8798,7 +8798,7 @@
                   "$ref": "#/definitions/lusterContext"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of lusterContext"
@@ -8807,7 +8807,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8847,7 +8847,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8868,7 +8868,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8900,7 +8900,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8932,7 +8932,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8962,7 +8962,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -8994,7 +8994,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9034,7 +9034,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9074,7 +9074,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9114,7 +9114,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9154,7 +9154,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9194,7 +9194,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9234,7 +9234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9274,7 +9274,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9314,7 +9314,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9354,7 +9354,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9393,7 +9393,7 @@
                   "$ref": "#/definitions/v1GetCostUsageV2Response"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetCostUsageV2Response"
@@ -9402,7 +9402,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9432,19 +9432,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCoverV1CostItem"
+                  "$ref": "#/definitions/blueapicoverv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCoverV1CostItem"
+              "title": "Stream result of blueapicoverv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9477,7 +9477,7 @@
                   "$ref": "#/definitions/v1Credit"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Credit"
@@ -9486,7 +9486,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9509,7 +9509,7 @@
                   "$ref": "#/definitions/v1CsvSetting"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CsvSetting"
@@ -9518,7 +9518,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9541,7 +9541,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9575,7 +9575,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9604,7 +9604,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9643,7 +9643,7 @@
                   "$ref": "#/definitions/v1CustomField"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CustomField"
@@ -9652,7 +9652,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9685,7 +9685,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9719,7 +9719,7 @@
                   "$ref": "#/definitions/v1GetCustomizedBillingServiceBillingGroupResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetCustomizedBillingServiceBillingGroupResponse"
@@ -9728,7 +9728,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9766,7 +9766,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9804,7 +9804,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9851,7 +9851,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9889,7 +9889,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9919,7 +9919,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -9959,7 +9959,7 @@
                   "$ref": "#/definitions/rippleCustomizedBillingService"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of rippleCustomizedBillingService"
@@ -9968,7 +9968,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10002,7 +10002,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10035,7 +10035,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10068,7 +10068,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10102,7 +10102,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10143,7 +10143,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10191,7 +10191,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10231,7 +10231,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10263,7 +10263,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10302,7 +10302,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10334,7 +10334,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10366,7 +10366,7 @@
                   "$ref": "#/definitions/v1GetCostForecastsDataResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetCostForecastsDataResponse"
@@ -10375,7 +10375,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10407,7 +10407,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10436,7 +10436,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10465,7 +10465,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10504,7 +10504,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10538,7 +10538,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10571,7 +10571,7 @@
                   "$ref": "#/definitions/v1GetFreeFormatResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetFreeFormatResponse"
@@ -10580,7 +10580,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10618,7 +10618,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10655,7 +10655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10688,7 +10688,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10727,7 +10727,7 @@
                   "$ref": "#/definitions/lusterHub"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of lusterHub"
@@ -10736,7 +10736,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10764,13 +10764,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiFlowV1GetInfoResponse"
+              "$ref": "#/definitions/blueapiflowv1GetInfoResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10792,7 +10792,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10814,7 +10814,7 @@
                   "$ref": "#/definitions/v1IntegrationStatus"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1IntegrationStatus"
@@ -10823,7 +10823,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10856,7 +10856,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10889,7 +10889,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10922,7 +10922,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10944,7 +10944,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -10979,7 +10979,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11019,7 +11019,7 @@
                   "$ref": "#/definitions/apiInvoiceMessage"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiInvoiceMessage"
@@ -11028,7 +11028,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11068,7 +11068,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11100,7 +11100,7 @@
                   "$ref": "#/definitions/v1ListInvoiceTemplateResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListInvoiceTemplateResponse"
@@ -11109,7 +11109,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11132,7 +11132,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11172,7 +11172,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11212,7 +11212,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11252,7 +11252,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11293,7 +11293,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11333,7 +11333,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11374,7 +11374,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11414,7 +11414,7 @@
                   "$ref": "#/definitions/v1ListInvoiceResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListInvoiceResponse"
@@ -11423,7 +11423,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11457,7 +11457,7 @@
                   "$ref": "#/definitions/v1TotalSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1TotalSection"
@@ -11466,7 +11466,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11500,7 +11500,7 @@
                   "$ref": "#/definitions/v1BillingGroupSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1BillingGroupSection"
@@ -11509,7 +11509,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11543,7 +11543,7 @@
                   "$ref": "#/definitions/v1OverViewSection"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1OverViewSection"
@@ -11552,7 +11552,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11586,7 +11586,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11608,7 +11608,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11630,7 +11630,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11668,7 +11668,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11690,7 +11690,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11712,7 +11712,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11751,7 +11751,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11784,7 +11784,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11807,7 +11807,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11840,7 +11840,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11873,7 +11873,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11906,7 +11906,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11939,7 +11939,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -11972,7 +11972,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12005,7 +12005,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12038,7 +12038,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12071,7 +12071,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12104,7 +12104,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12137,7 +12137,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12170,7 +12170,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12193,7 +12193,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12225,7 +12225,7 @@
                   "$ref": "#/definitions/v1Member"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Member"
@@ -12234,7 +12234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12267,7 +12267,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12288,7 +12288,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12321,7 +12321,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12354,7 +12354,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12387,7 +12387,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12420,7 +12420,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12453,7 +12453,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12486,7 +12486,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12519,7 +12519,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12549,7 +12549,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12589,7 +12589,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12622,7 +12622,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12655,7 +12655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12685,7 +12685,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12717,7 +12717,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12749,7 +12749,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12789,7 +12789,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12829,7 +12829,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12862,7 +12862,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12895,7 +12895,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12927,7 +12927,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -12983,7 +12983,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13039,7 +13039,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13071,7 +13071,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13104,7 +13104,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13137,7 +13137,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13171,7 +13171,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13203,7 +13203,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13237,7 +13237,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13276,7 +13276,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13329,7 +13329,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13369,7 +13369,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13408,7 +13408,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13441,7 +13441,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13475,7 +13475,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13507,7 +13507,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13540,7 +13540,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13573,7 +13573,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13603,7 +13603,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13633,7 +13633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13673,7 +13673,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13707,13 +13707,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1CreateOrgResponse"
+              "$ref": "#/definitions/blueapivortexv1CreateOrgResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13723,7 +13723,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1CreateOrgRequest"
+              "$ref": "#/definitions/blueapivortexv1CreateOrgRequest"
             }
           }
         ],
@@ -13746,7 +13746,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13767,7 +13767,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13794,13 +13794,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiCoverV1ListExchangeRatesResponse"
+              "$ref": "#/definitions/blueapicoverv1ListExchangeRatesResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13839,7 +13839,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13889,19 +13889,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/gcV1Org"
+                  "$ref": "#/definitions/gcv1Org"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of gcV1Org"
+              "title": "Stream result of gcv1Org"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13934,7 +13934,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -13966,7 +13966,7 @@
                   "$ref": "#/definitions/v1Product"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Product"
@@ -13975,7 +13975,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14008,7 +14008,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14041,7 +14041,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14074,7 +14074,7 @@
                   "$ref": "#/definitions/v1Project"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Project"
@@ -14083,7 +14083,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14116,7 +14116,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14147,7 +14147,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14178,7 +14178,7 @@
                   "$ref": "#/definitions/v1ListProjectToTeamResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListProjectToTeamResponse"
@@ -14187,7 +14187,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14219,7 +14219,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14251,7 +14251,7 @@
                   "$ref": "#/definitions/v1Prompt"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Prompt"
@@ -14260,7 +14260,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14292,7 +14292,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14324,7 +14324,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14359,7 +14359,7 @@
                   "$ref": "#/definitions/v1ListRecommendationResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListRecommendationResponse"
@@ -14368,7 +14368,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14401,7 +14401,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14450,7 +14450,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14483,7 +14483,7 @@
                   "$ref": "#/definitions/v1GetExecutionStatusResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetExecutionStatusResponse"
@@ -14492,7 +14492,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14515,7 +14515,7 @@
                   "$ref": "#/definitions/v1ListRecommendationResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListRecommendationResponse"
@@ -14524,7 +14524,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14641,7 +14641,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14674,7 +14674,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14748,7 +14748,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14781,7 +14781,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14824,7 +14824,7 @@
                   "$ref": "#/definitions/v1RecommendationSummary"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1RecommendationSummary"
@@ -14833,7 +14833,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14866,7 +14866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14887,7 +14887,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14920,7 +14920,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -14979,7 +14979,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15011,7 +15011,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15044,7 +15044,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15078,7 +15078,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15110,7 +15110,7 @@
                   "$ref": "#/definitions/v1ReportSchedule"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ReportSchedule"
@@ -15119,7 +15119,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15152,7 +15152,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15192,7 +15192,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15225,7 +15225,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15256,7 +15256,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15297,7 +15297,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15331,7 +15331,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15376,7 +15376,7 @@
                   "$ref": "#/definitions/rippleReseller"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of rippleReseller"
@@ -15385,7 +15385,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15415,7 +15415,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15449,7 +15449,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15487,7 +15487,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15517,7 +15517,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15557,7 +15557,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15635,7 +15635,7 @@
                   "$ref": "#/definitions/v1ResourceAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ResourceAccount"
@@ -15644,7 +15644,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15683,7 +15683,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15746,7 +15746,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15772,13 +15772,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15812,7 +15812,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15846,7 +15846,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15881,7 +15881,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15911,7 +15911,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15949,7 +15949,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -15989,7 +15989,7 @@
                   "$ref": "#/definitions/v1AccountInvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AccountInvoiceServiceDiscounts"
@@ -15998,7 +15998,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16039,7 +16039,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16079,7 +16079,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16109,7 +16109,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16139,7 +16139,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16177,7 +16177,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16211,13 +16211,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16255,7 +16255,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16279,13 +16279,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts"
+              "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16325,7 +16325,7 @@
                   "$ref": "#/definitions/v1Service"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Service"
@@ -16334,7 +16334,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16374,7 +16374,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16405,19 +16405,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiBillingV1InvoiceServiceDiscounts"
+                  "$ref": "#/definitions/blueapibillingv1InvoiceServiceDiscounts"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiBillingV1InvoiceServiceDiscounts"
+              "title": "Stream result of blueapibillingv1InvoiceServiceDiscounts"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16451,7 +16451,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16483,7 +16483,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16515,7 +16515,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16547,7 +16547,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16577,7 +16577,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16617,7 +16617,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16651,7 +16651,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16683,7 +16683,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16722,7 +16722,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16755,7 +16755,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16789,7 +16789,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16828,7 +16828,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16858,7 +16858,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16898,7 +16898,7 @@
                   "$ref": "#/definitions/lusterSpace"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of lusterSpace"
@@ -16907,7 +16907,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16938,19 +16938,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/billingV1TagData"
+                  "$ref": "#/definitions/billingv1TagData"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of billingV1TagData"
+              "title": "Stream result of billingv1TagData"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -16987,7 +16987,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17019,7 +17019,7 @@
                   "$ref": "#/definitions/v1Team"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Team"
@@ -17028,7 +17028,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17060,7 +17060,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17090,7 +17090,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17116,13 +17116,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiPrismV1TestResponse"
+              "$ref": "#/definitions/blueapiprismv1TestResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17139,13 +17139,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1TestResponse"
+              "$ref": "#/definitions/blueapivortexv1TestResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17176,7 +17176,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17197,7 +17197,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17230,7 +17230,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17253,7 +17253,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17286,7 +17286,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17319,7 +17319,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17352,7 +17352,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17396,7 +17396,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17429,7 +17429,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17489,7 +17489,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17522,7 +17522,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17555,7 +17555,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17585,7 +17585,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17615,7 +17615,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17655,7 +17655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17676,7 +17676,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17709,7 +17709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17739,7 +17739,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17769,7 +17769,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17809,7 +17809,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17839,7 +17839,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17869,7 +17869,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17909,7 +17909,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17943,7 +17943,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -17973,7 +17973,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18006,13 +18006,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiVortexV1GetUserResponse"
+              "$ref": "#/definitions/blueapivortexv1GetUserResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18043,7 +18043,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18066,7 +18066,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18093,13 +18093,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiCoverV1GetUserResponse"
+              "$ref": "#/definitions/blueapicoverv1GetUserResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18128,7 +18128,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18159,7 +18159,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18198,7 +18198,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18236,7 +18236,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18269,7 +18269,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18290,7 +18290,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18323,7 +18323,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18356,7 +18356,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18389,7 +18389,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18412,7 +18412,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18452,7 +18452,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18499,7 +18499,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18532,7 +18532,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18562,7 +18562,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18592,7 +18592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18632,7 +18632,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18671,7 +18671,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18710,7 +18710,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18750,7 +18750,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18790,7 +18790,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18829,7 +18829,7 @@
                   "$ref": "#/definitions/v1Workflow"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1Workflow"
@@ -18838,7 +18838,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18871,7 +18871,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18911,7 +18911,7 @@
                   "$ref": "#/definitions/v1ProxyCreateCompletionResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ProxyCreateCompletionResponse"
@@ -18920,7 +18920,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18954,7 +18954,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -18984,7 +18984,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19025,7 +19025,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19062,19 +19062,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiAccount"
+                  "$ref": "#/definitions/blueapiapiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiAccount"
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19112,13 +19112,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19158,7 +19158,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19195,19 +19195,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiAccount"
+                  "$ref": "#/definitions/blueapiapiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiAccount"
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19253,7 +19253,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19285,13 +19285,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19336,7 +19336,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19367,13 +19367,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19420,7 +19420,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19460,7 +19460,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19500,7 +19500,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19548,7 +19548,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19596,7 +19596,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19644,7 +19644,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19692,7 +19692,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19732,7 +19732,7 @@
                   "$ref": "#/definitions/v1AdjustmentEntry"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AdjustmentEntry"
@@ -19741,7 +19741,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19782,7 +19782,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19822,7 +19822,7 @@
                   "$ref": "#/definitions/v1AdjustmentEntryItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1AdjustmentEntryItem"
@@ -19831,7 +19831,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19869,19 +19869,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19915,13 +19915,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiWaveBudgetAlert"
+              "$ref": "#/definitions/apiwaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19959,7 +19959,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -19990,13 +19990,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiWaveBudgetAlert"
+              "$ref": "#/definitions/apiwaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20035,13 +20035,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiWaveBudgetAlert"
+              "$ref": "#/definitions/apiwaveBudgetAlert"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20088,7 +20088,7 @@
                   "$ref": "#/definitions/apiAccountOriginalResource"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiAccountOriginalResource"
@@ -20097,7 +20097,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20137,7 +20137,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20190,7 +20190,7 @@
                   "$ref": "#/definitions/v1GetChildBillingGroupCustomizedBillingServiceResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetChildBillingGroupCustomizedBillingServiceResponse"
@@ -20199,7 +20199,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20237,7 +20237,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20285,7 +20285,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20323,7 +20323,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20370,7 +20370,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20421,7 +20421,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20475,7 +20475,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20514,7 +20514,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20560,7 +20560,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20590,7 +20590,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20631,7 +20631,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20670,7 +20670,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20702,7 +20702,7 @@
                   "$ref": "#/definitions/v1CalculatorCostModifier"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CalculatorCostModifier"
@@ -20711,7 +20711,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20742,7 +20742,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20783,7 +20783,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20823,7 +20823,7 @@
                   "$ref": "#/definitions/v1ListCalculatorRunningAccountsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ListCalculatorRunningAccountsResponse"
@@ -20832,7 +20832,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20872,7 +20872,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20933,7 +20933,7 @@
                   "$ref": "#/definitions/v1CostAttributeItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1CostAttributeItem"
@@ -20942,7 +20942,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -20982,7 +20982,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21013,7 +21013,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21054,7 +21054,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21091,7 +21091,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21138,7 +21138,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21186,7 +21186,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21224,19 +21224,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21276,7 +21276,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21323,7 +21323,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21370,7 +21370,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21412,13 +21412,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiBillingV1ListExchangeRatesResponse"
+              "$ref": "#/definitions/blueapibillingv1ListExchangeRatesResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21457,7 +21457,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21524,7 +21524,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21577,7 +21577,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21630,7 +21630,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21690,7 +21690,7 @@
                   "$ref": "#/definitions/waveAdjustment"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of waveAdjustment"
@@ -21699,7 +21699,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21739,7 +21739,7 @@
                   "$ref": "#/definitions/v1ReadInvoiceIdsResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1ReadInvoiceIdsResponse"
@@ -21748,7 +21748,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21786,19 +21786,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21836,19 +21836,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiApiAccount"
+                  "$ref": "#/definitions/blueapiapiAccount"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiApiAccount"
+              "title": "Stream result of blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21879,13 +21879,13 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/blueapiApiAccount"
+              "$ref": "#/definitions/blueapiapiAccount"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21926,7 +21926,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -21967,7 +21967,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22015,7 +22015,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22053,7 +22053,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22093,7 +22093,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22141,7 +22141,7 @@
                   "$ref": "#/definitions/v1GetPayerAccountImportHistoryResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1GetPayerAccountImportHistoryResponse"
@@ -22150,7 +22150,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22196,7 +22196,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22236,7 +22236,7 @@
                   "$ref": "#/definitions/v1PayerAccountExtended"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1PayerAccountExtended"
@@ -22245,7 +22245,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22285,7 +22285,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22324,7 +22324,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22371,7 +22371,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22418,7 +22418,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22456,7 +22456,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22496,7 +22496,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22536,7 +22536,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22575,7 +22575,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22611,19 +22611,19 @@
               "type": "object",
               "properties": {
                 "result": {
-                  "$ref": "#/definitions/blueapiCostV1CostItem"
+                  "$ref": "#/definitions/blueapicostv1CostItem"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
-              "title": "Stream result of blueapiCostV1CostItem"
+              "title": "Stream result of blueapicostv1CostItem"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22663,7 +22663,7 @@
                   "$ref": "#/definitions/apiCostTag"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiCostTag"
@@ -22672,7 +22672,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22718,7 +22718,7 @@
                   "$ref": "#/definitions/apiCostTag"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of apiCostTag"
@@ -22727,7 +22727,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22773,7 +22773,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22810,7 +22810,7 @@
                   "$ref": "#/definitions/v1TagsAddingSetting"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1TagsAddingSetting"
@@ -22819,7 +22819,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22854,7 +22854,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22899,7 +22899,7 @@
                   "$ref": "#/definitions/rippleUntaggedGroup"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of rippleUntaggedGroup"
@@ -22908,7 +22908,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22948,7 +22948,7 @@
                   "$ref": "#/definitions/v1UsageCostsDrift"
                 },
                 "error": {
-                  "$ref": "#/definitions/googleRpcStatus"
+                  "$ref": "#/definitions/googlerpcStatus"
                 }
               },
               "title": "Stream result of v1UsageCostsDrift"
@@ -22957,7 +22957,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -22997,7 +22997,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/googlerpcStatus"
             }
           }
         },
@@ -23336,7 +23336,7 @@
           "description": "Required\nValid values:\n`InvoiceCalculationStarted`,\n`InvoiceCalculationFinished`,\n`CurUpdatedAfterInvoice`.\n`AccountBudgetAlert`."
         },
         "account": {
-          "$ref": "#/definitions/adminV1NotificationAccount",
+          "$ref": "#/definitions/adminv1NotificationAccount",
           "description": "Optional. only available Wave(Pro)."
         }
       },
@@ -23607,7 +23607,7 @@
           "description": "Optional. groups to apply the invoices setting\nthis is ignored if allGroups is true."
         },
         "invoiceSetting": {
-          "$ref": "#/definitions/billingV1InvoiceSettings",
+          "$ref": "#/definitions/billingv1InvoiceSettings",
           "description": "Required. Invoice setting."
         }
       }
@@ -23787,7 +23787,7 @@
           "description": "Optional. groups to apply the invoices setting\nthis is ignored if allGroups is true."
         },
         "invoiceSetting": {
-          "$ref": "#/definitions/billingV1InvoiceSettings",
+          "$ref": "#/definitions/billingv1InvoiceSettings",
           "description": "Required. Invoice setting."
         }
       }
@@ -24270,7 +24270,7 @@
       "type": "object",
       "properties": {
         "invoiceServiceDiscounts": {
-          "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts",
+          "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts",
           "description": "Required. The updated invoice service discounts object."
         },
         "updateMask": {
@@ -24582,7 +24582,7 @@
       "type": "object",
       "properties": {
         "budgetAlert": {
-          "$ref": "#/definitions/apiWaveBudgetAlert",
+          "$ref": "#/definitions/apiwaveBudgetAlert",
           "description": "Required. Budget alert setting."
         }
       },
@@ -24592,7 +24592,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiApiBudget"
+          "$ref": "#/definitions/blueapiapiBudget"
         }
       },
       "title": "Request message for CreateAccountBudget"
@@ -25193,7 +25193,7 @@
       "type": "object",
       "properties": {
         "budgetAlert": {
-          "$ref": "#/definitions/apiWaveBudgetAlert",
+          "$ref": "#/definitions/apiwaveBudgetAlert",
           "description": "Required. Budget alert setting.\n\nSet only the setting value to be changed.\nFor example, If you want to change only daily value, set `{\"budget\":[{\"id\":\"daily\",\"value\":100,\"enabled\":true}}` as a parameter\nThe same goes for notification. If you want to change only email value, set `{\"notification\":[{\"id\":\"email\",\"destination\":\"budgetalert-example@alphaus.cloud\",\"enabled\":true}}` as a parameter"
         }
       },
@@ -25203,7 +25203,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiApiBudget"
+          "$ref": "#/definitions/blueapiapiBudget"
         }
       },
       "title": "Request message for UpdateAccountBudget"
@@ -25617,7 +25617,7 @@
           "title": "Optional. Description of the forecast"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup",
+          "$ref": "#/definitions/apicoverCostGroup",
           "title": "Optional. Cost Group Id and Name"
         },
         "pastActualCostRange": {
@@ -25711,11 +25711,11 @@
           "title": "GCP Options"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apiCoverAzureOptions",
+          "$ref": "#/definitions/apicoverAzureOptions",
           "title": "Azure Options"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apiCoverAwsOptions",
+          "$ref": "#/definitions/apicoverAwsOptions",
           "title": "AWS Options"
         },
         "accountType": {
@@ -28113,7 +28113,7 @@
         }
       }
     },
-    "adminV1NotificationAccount": {
+    "adminv1NotificationAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -28157,7 +28157,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiFeeDetails"
+            "$ref": "#/definitions/blueapiapiFeeDetails"
           },
           "title": "feeDetails: Includes details of re-caluclated fee data"
         },
@@ -28196,7 +28196,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           }
         }
       }
@@ -28355,374 +28355,6 @@
       },
       "description": "AuditExportData resource definition."
     },
-    "apiAwsChartData": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string"
-        },
-        "actualOndemand": {
-          "type": "number",
-          "format": "double"
-        },
-        "actualCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "utilization": {
-          "type": "number",
-          "format": "double"
-        }
-      }
-    },
-    "apiAwsCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "description": "The account being queried."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "type": {
-          "type": "string"
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "productCode": {
-          "type": "string",
-          "description": "The product code for an AWS service, such as `AmazonEC2`, `AmazonRDS`, etc. This can also be an Alphaus-specified custom value."
-        },
-        "serviceCode": {
-          "type": "string",
-          "description": "The CUR service code of the lineitem, if applicable. Sometimes, this is the same as `productCode`, a subset of `productCode`, an Alphaus-specified custom value, or empty."
-        },
-        "region": {
-          "type": "string",
-          "description": "The region of the lineitem, if applicable."
-        },
-        "zone": {
-          "type": "string",
-          "description": "The zone of the lineitem, if applicable."
-        },
-        "usageType": {
-          "type": "string",
-          "description": "The CUR usage type of the lineitem, if applicable."
-        },
-        "instanceType": {
-          "type": "string",
-          "description": "The CUR instance type of the lineitem, if applicable."
-        },
-        "operation": {
-          "type": "string",
-          "description": "The CUR operation of the lineitem, if applicable."
-        },
-        "invoiceId": {
-          "type": "string",
-          "description": "The AWS invoice ID of the lineitem, if applicable."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of the lineitem, if applicable."
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "The resource id of the lineitem, if applicable. At the moment, this is not yet fully supported."
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "costCategories": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "usage": {
-          "type": "number",
-          "format": "double",
-          "description": "Only set when `description` and/or `resourceId` attributes are specified."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The true cost (calculated) for this lineitem."
-        },
-        "unblendedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "The unblended cost as reflected in the CUR for this lineitem."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The base currency for `cost`, `unblendedCost`, `effectiveCost`, `amortizedCost`. Always set to `USD`, CUR's default currency."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
-        },
-        "targetCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `cost`."
-        },
-        "targetUnblendedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `unblendedCost`."
-        },
-        "targetCurrency": {
-          "type": "string",
-          "description": "The currency set by `toCurrency`."
-        },
-        "effectiveCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "targetEffectiveCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `effectiveCost`."
-        },
-        "amortizedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "targetAmortizedCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `amortizedCost`."
-        },
-        "tagId": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "string",
-          "description": "Get last update in UNIX time format."
-        },
-        "metadata": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiKeyValue"
-          },
-          "description": "Various metadata associated with this lineitem."
-        }
-      }
-    },
-    "apiAwsCostAttribute": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string"
-        },
-        "groupId": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "serviceCode": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "zone": {
-          "type": "string"
-        },
-        "usageType": {
-          "type": "string"
-        },
-        "instanceType": {
-          "type": "string"
-        },
-        "operation": {
-          "type": "string"
-        },
-        "invoiceId": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "resourceId": {
-          "type": "string"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "costCategories": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiAzureCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "description": "The account being queried."
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "serviceName": {
-          "type": "string",
-          "description": "The service name, such as `Software License`, `Cognosys`, `SendGrid`, `New-Commerce ERP Software License`, etc."
-        },
-        "productName": {
-          "type": "string",
-          "description": "The product code for an Azure service, such as `Dsv4 Series Windows VM`, `CentOS 7.6`, etc."
-        },
-        "region": {
-          "type": "string",
-          "description": "The region of lineitem, if applicable."
-        },
-        "chargeType": {
-          "type": "string",
-          "description": "The charge type of lineitem, if applicable. Such as `New`, `CycleCharge`, `Prorate fees when cancel`, etc."
-        },
-        "description": {
-          "type": "string",
-          "description": "The description of lineitem, if applicable."
-        },
-        "billableQuantity": {
-          "type": "number",
-          "format": "double",
-          "description": "The billable quantity of lineitem, if applicable."
-        },
-        "effectiveUnitPrice": {
-          "type": "number",
-          "format": "double",
-          "description": "The effective unit price of lineitem, if applicable."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The true cost (calculated) for this lineitem."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The base currency for `cost`."
-        },
-        "exchangeRate": {
-          "type": "number",
-          "format": "double",
-          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
-        },
-        "targetCost": {
-          "type": "number",
-          "format": "double",
-          "description": "Converted `cost`."
-        },
-        "targetCurrency": {
-          "type": "string",
-          "description": "The currency set by `toCurrency`."
-        },
-        "timeInterval": {
-          "type": "string",
-          "description": "The time interval of lineitem, if applicable. Format is `yyyy-MM-ddThh:MM:ssZ/yyyy-mm-ddTHH:mm:ssZ` (for example 2020-09-16T00:00:00Z/2021-09-24T00:00:00Z)."
-        },
-        "billingType": {
-          "type": "string",
-          "description": "The billing type of lineitem, if applicable. Such as `MARKETPLACE`, `UPFRONT`, `Refund`, `Credit` and `OTHERS`."
-        },
-        "alternateId": {
-          "type": "string",
-          "description": "The alternate ID of lineitem, if applicable."
-        },
-        "domainName": {
-          "type": "string",
-          "description": "The domain name of lineitem, if applicable."
-        },
-        "operation": {
-          "type": "string",
-          "description": "The operation of lineitem, if applicable. Such as `Cool LRS Write Operations`, `Cool LRS Data Write`, `Standard Data Transfer Out`, etc."
-        },
-        "usageType": {
-          "type": "string",
-          "description": "The usage type of lineitem, if applicable. Such as `Standard HDD Managed Disks`, `Tables`, `Blob Storage`, etc."
-        },
-        "instanceType": {
-          "type": "string",
-          "description": "The instance type of lineitem, if applicable. Such as `Gateway`, `Standard_B2s`, `Standard_D4s_v3`, etc."
-        },
-        "category": {
-          "type": "string",
-          "description": "The category of lineitem, if applicable. Such as `Software License`, `Marketplace`, `RI`, `Other`, etc."
-        },
-        "subscriptionId": {
-          "type": "string",
-          "description": "The subscription id."
-        },
-        "entitlementId": {
-          "type": "string",
-          "description": "The entitlement id."
-        },
-        "resourceGroup": {
-          "type": "string",
-          "description": "The resource group of the lineitem, if applicable."
-        }
-      }
-    },
-    "apiAzureCostAttribute": {
-      "type": "object",
-      "properties": {
-        "customerId": {
-          "type": "string"
-        },
-        "subscriptionId": {
-          "type": "string"
-        },
-        "entitlementId": {
-          "type": "string"
-        },
-        "groupId": {
-          "type": "string"
-        },
-        "productId": {
-          "type": "string"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "skuId": {
-          "type": "string"
-        },
-        "skuName": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "domainName": {
-          "type": "string"
-        }
-      }
-    },
     "apiBillingGroupForecast": {
       "type": "object",
       "properties": {
@@ -28819,476 +28451,6 @@
             "$ref": "#/definitions/apiKeyValue"
           },
           "description": "The attributes (key/value pair) of the costtag."
-        }
-      }
-    },
-    "apiCoverAWSRecommendations": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "accountId": {
-          "type": "string"
-        },
-        "accountName": {
-          "type": "string"
-        },
-        "instanceId": {
-          "type": "string"
-        },
-        "instanceName": {
-          "type": "string"
-        },
-        "service": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string"
-        },
-        "costGroup": {
-          "type": "string"
-        },
-        "recommendation": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "estsavings": {
-          "type": "number",
-          "format": "double"
-        },
-        "estcost": {
-          "type": "number",
-          "format": "double"
-        },
-        "estsavingsPercentage": {
-          "type": "number",
-          "format": "double"
-        },
-        "resourceArn": {
-          "type": "string"
-        },
-        "restartNeeded": {
-          "type": "boolean"
-        },
-        "rollbackPossible": {
-          "type": "boolean"
-        },
-        "lastUpdatedAt": {
-          "type": "string"
-        },
-        "recommendationGroup": {
-          "type": "string"
-        },
-        "category": {
-          "type": "string"
-        },
-        "purchaseRIRecommendationDetails": {
-          "$ref": "#/definitions/coverPurchaseRIRecommendationDetails"
-        },
-        "savingsPlanRecommendationDetails": {
-          "$ref": "#/definitions/coverSavingsPlanRecommendationDetails"
-        },
-        "rightSizingRecommendationDetails": {
-          "$ref": "#/definitions/coverRightSizingRecommendationDetails"
-        },
-        "upgradeRecommendationDetails": {
-          "$ref": "#/definitions/coverUpgradeRecommendationDetails"
-        },
-        "migrateRecommendationDetails": {
-          "$ref": "#/definitions/coverMigrateRecommendationDetails"
-        },
-        "stopInstanceRecommendationDetails": {
-          "$ref": "#/definitions/coverStopInstanceRecommendationDetails"
-        },
-        "deleteRecommendationDetails": {
-          "$ref": "#/definitions/coverDeleteRecommendationDetails"
-        },
-        "otherRecommendationDetails": {
-          "$ref": "#/definitions/coverOtherRecommendationDetails"
-        }
-      }
-    },
-    "apiCoverAccount": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "title": "account, subscription, project"
-        }
-      }
-    },
-    "apiCoverAwsOptions": {
-      "type": "object",
-      "properties": {
-        "AccountName": {
-          "type": "string"
-        },
-        "PayerId": {
-          "type": "string"
-        },
-        "RoleArn": {
-          "type": "string"
-        },
-        "ExternalId": {
-          "type": "string"
-        },
-        "StackId": {
-          "type": "string"
-        },
-        "StackRegion": {
-          "type": "string"
-        },
-        "TemplateUrl": {
-          "type": "string"
-        },
-        "BucketName": {
-          "type": "string"
-        },
-        "Prefix": {
-          "type": "string"
-        },
-        "ReportName": {
-          "type": "string"
-        },
-        "registrationStatus": {
-          "$ref": "#/definitions/coverRegistrationStatus"
-        },
-        "Status": {
-          "type": "string"
-        },
-        "RegistrationMethod": {
-          "type": "string",
-          "title": "Valid values for now are: 'console', 'terraform'. default would be 'console'"
-        },
-        "templateVersion": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverAzureOptions": {
-      "type": "object",
-      "properties": {
-        "accountName": {
-          "type": "string"
-        },
-        "azureCustomerId": {
-          "type": "string"
-        },
-        "azurePlanId": {
-          "type": "string"
-        },
-        "serviceAcct": {
-          "type": "string"
-        },
-        "partnerAcct": {
-          "type": "string"
-        },
-        "companyId": {
-          "type": "string"
-        },
-        "payerId": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverBudgetAlert": {
-      "type": "object",
-      "properties": {
-        "threshold": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/coverThreshold"
-          }
-        },
-        "channels": {
-          "$ref": "#/definitions/coverAlertChannels"
-        }
-      }
-    },
-    "apiCoverCategory": {
-      "type": "object",
-      "properties": {
-        "display": {
-          "type": "string"
-        },
-        "query": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverCostCalculation": {
-      "type": "object",
-      "properties": {
-        "estCostAfterDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "estCostBeforeDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "otherDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "savingsPlanDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "estNetUnusedAmortizedCommitments": {
-          "type": "number",
-          "format": "double"
-        },
-        "reservedInstanceDiscount": {
-          "type": "number",
-          "format": "double"
-        },
-        "usageTypes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiCoverUsageTypes"
-          }
-        }
-      }
-    },
-    "apiCoverCostGroup": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "title": "cost group name"
-        }
-      }
-    },
-    "apiCoverEBSDetails": {
-      "type": "object",
-      "properties": {
-        "currentEBSDetails": {
-          "$ref": "#/definitions/coverCurrentEBSDetails"
-        },
-        "upgradeEBSDetails": {
-          "$ref": "#/definitions/coverEBSRecommendationDetails"
-        }
-      }
-    },
-    "apiCoverEC2Details": {
-      "type": "object",
-      "properties": {
-        "instanceType": {
-          "type": "string"
-        },
-        "tenancy": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverMemoryDBDetails": {
-      "type": "object",
-      "properties": {
-        "family": {
-          "type": "string"
-        },
-        "nodeType": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRDSDetails": {
-      "type": "object",
-      "properties": {
-        "dbEdition": {
-          "type": "string"
-        },
-        "dbEngine": {
-          "type": "string"
-        },
-        "deploymentOptions": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        },
-        "instanceType": {
-          "type": "string"
-        },
-        "licenseModel": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRecommendationDetail": {
-      "type": "object",
-      "properties": {
-        "recommendation": {
-          "type": "string"
-        },
-        "recommendedResourceType": {
-          "type": "string"
-        },
-        "estimatedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "estimatedSavings": {
-          "type": "number",
-          "format": "double"
-        },
-        "region": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRedshiftDetails": {
-      "type": "object",
-      "properties": {
-        "currentGeneration": {
-          "type": "boolean"
-        },
-        "nodeType": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverResult": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverRole": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "costgroupsIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiCoverTagData": {
-      "type": "object",
-      "properties": {
-        "tagKey": {
-          "type": "string"
-        },
-        "tagValue": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "apiCoverUsageTypes": {
-      "type": "object",
-      "properties": {
-        "operation": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "unit": {
-          "type": "string"
-        },
-        "usageAmount": {
-          "type": "number",
-          "format": "double"
-        },
-        "usageType": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverUser": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/coverUserRole"
-          }
-        },
-        "invitedBy": {
-          "type": "object"
-        },
-        "lastUpdated": {
-          "type": "string"
-        },
-        "createdOn": {
-          "type": "string"
-        },
-        "avatar": {
-          "type": "string"
-        },
-        "activated": {
-          "type": "boolean"
-        },
-        "colorTheme": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCoverUtilizationData": {
-      "type": "object",
-      "properties": {
-        "date": {
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "format": "float"
         }
       }
     },
@@ -29577,71 +28739,6 @@
         }
       }
     },
-    "apiGcpCost": {
-      "type": "object",
-      "properties": {
-        "account": {
-          "type": "string",
-          "title": "account data"
-        },
-        "groupId": {
-          "type": "string",
-          "description": "The group id the account is associated with during the query."
-        },
-        "date": {
-          "type": "string",
-          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
-        },
-        "invoiceMonth": {
-          "type": "string",
-          "description": "The invoice.month of the lineitem, if applicable."
-        },
-        "service": {
-          "type": "string",
-          "description": "The service.Description of the lineitem, if applicable."
-        },
-        "sku": {
-          "type": "string",
-          "description": "The sku.Description of the lineitem, if applicable."
-        },
-        "region": {
-          "type": "string",
-          "description": "The location.region of the lineitem, if applicable."
-        },
-        "zone": {
-          "type": "string",
-          "description": "The location.zone of the lineitem, if applicable."
-        },
-        "creditsType": {
-          "type": "string",
-          "description": "The credits.type of the lineitem, if applicable."
-        },
-        "creditsName": {
-          "type": "string",
-          "description": "The credits.name of the lineitem, if applicable."
-        },
-        "usageUnit": {
-          "type": "string",
-          "description": "The usage.pricing_unit of the lineitem, if applicable."
-        },
-        "usageAmount": {
-          "type": "number",
-          "format": "double",
-          "description": "The usage.amount_in_pricing_units of the lineitem, if applicable."
-        },
-        "baseCurrency": {
-          "type": "string",
-          "description": "The currency of the lineitem, if applicable."
-        },
-        "cost": {
-          "type": "number",
-          "format": "double",
-          "description": "The cost of the lineitem, if applicable."
-        }
-      },
-      "description": "see gcp billing data schema details:[https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables]",
-      "title": "Cost for Api Response"
-    },
     "apiGroupCustomDetails": {
       "type": "object",
       "properties": {
@@ -29813,38 +28910,6 @@
         }
       },
       "description": "KeyValueMap resource definition."
-    },
-    "apiLusterLabel": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The label id."
-        },
-        "name": {
-          "type": "string",
-          "description": "The label name."
-        },
-        "color": {
-          "type": "string",
-          "description": "The label color.\nformat: HEX color code ( #FF0000 )."
-        },
-        "description": {
-          "type": "string",
-          "description": "The label description."
-        },
-        "createdAt": {
-          "type": "string",
-          "title": "The label createdAt.\n\"created_at\": \"2023-10-27T10:00:00Z\"",
-          "readOnly": true
-        },
-        "updatedAt": {
-          "type": "string",
-          "title": "The label updatedAt.\n\"updated_at\": \"2023-10-27T10:00:00Z\"",
-          "readOnly": true
-        }
-      },
-      "title": "The message defines the label"
     },
     "apiMSTeamsChannel": {
       "type": "object",
@@ -30136,80 +29201,6 @@
         }
       }
     },
-    "apiRippleAccessGroup": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "billingGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "description": "AccessGroup resource definition."
-    },
-    "apiRippleOrg": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The unique name (or id) of the organization."
-        },
-        "email": {
-          "type": "string",
-          "description": "The registered email of the organization."
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "The metadata (key/value pair) of the organization. If hierarchy is supported, it will be\nseparated by '/', such as 'metakey/subkey=value'. See https://alphauslabs.github.io/blueapi/\nfor the list of supported attributes."
-        }
-      },
-      "description": "Org resource definition."
-    },
-    "apiRippleV1InvoiceServiceDiscounts": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The invoice service discounts id."
-        },
-        "name": {
-          "type": "string",
-          "description": "The invoice service discount name.\nmust be 1-60 characters long."
-        },
-        "description": {
-          "type": "string",
-          "description": "The invoice service discount description.\nMaximum 150 characters long."
-        },
-        "setting": {
-          "$ref": "#/definitions/v1InvoiceServiceDiscountsSetting",
-          "description": "The invoice service discount setting."
-        },
-        "created": {
-          "type": "string",
-          "description": "Timestamp associated with the created.",
-          "readOnly": true
-        },
-        "updated": {
-          "type": "string",
-          "description": "Timestamp associated with the updated.",
-          "readOnly": true
-        }
-      },
-      "description": "InvoiceServiceDiscounts resource definition."
-    },
     "apiSlackChannel": {
       "type": "object",
       "properties": {
@@ -30353,13 +29344,1022 @@
           "title": "total: Includes data on billing totals"
         },
         "settings": {
-          "$ref": "#/definitions/blueapiApiInvoiceSettings",
+          "$ref": "#/definitions/blueapiapiInvoiceSettings",
           "title": "settings: Includes settings related to billing"
         }
       },
       "description": "VendorDetail resource definition."
     },
-    "apiWaveBudget": {
+    "apiawsChartData": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "actualOndemand": {
+          "type": "number",
+          "format": "double"
+        },
+        "actualCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "utilization": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "apiawsCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "The account being queried."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "type": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "productCode": {
+          "type": "string",
+          "description": "The product code for an AWS service, such as `AmazonEC2`, `AmazonRDS`, etc. This can also be an Alphaus-specified custom value."
+        },
+        "serviceCode": {
+          "type": "string",
+          "description": "The CUR service code of the lineitem, if applicable. Sometimes, this is the same as `productCode`, a subset of `productCode`, an Alphaus-specified custom value, or empty."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of the lineitem, if applicable."
+        },
+        "zone": {
+          "type": "string",
+          "description": "The zone of the lineitem, if applicable."
+        },
+        "usageType": {
+          "type": "string",
+          "description": "The CUR usage type of the lineitem, if applicable."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The CUR instance type of the lineitem, if applicable."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The CUR operation of the lineitem, if applicable."
+        },
+        "invoiceId": {
+          "type": "string",
+          "description": "The AWS invoice ID of the lineitem, if applicable."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the lineitem, if applicable."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The resource id of the lineitem, if applicable. At the moment, this is not yet fully supported."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "usage": {
+          "type": "number",
+          "format": "double",
+          "description": "Only set when `description` and/or `resourceId` attributes are specified."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The true cost (calculated) for this lineitem."
+        },
+        "unblendedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "The unblended cost as reflected in the CUR for this lineitem."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The base currency for `cost`, `unblendedCost`, `effectiveCost`, `amortizedCost`. Always set to `USD`, CUR's default currency."
+        },
+        "exchangeRate": {
+          "type": "number",
+          "format": "double",
+          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
+        },
+        "targetCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `cost`."
+        },
+        "targetUnblendedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `unblendedCost`."
+        },
+        "targetCurrency": {
+          "type": "string",
+          "description": "The currency set by `toCurrency`."
+        },
+        "effectiveCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "targetEffectiveCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `effectiveCost`."
+        },
+        "amortizedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "targetAmortizedCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `amortizedCost`."
+        },
+        "tagId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Get last update in UNIX time format."
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiKeyValue"
+          },
+          "description": "Various metadata associated with this lineitem."
+        }
+      }
+    },
+    "apiawsCostAttribute": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "serviceCode": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "zone": {
+          "type": "string"
+        },
+        "usageType": {
+          "type": "string"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "invoiceId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiazureCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "The account being queried."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "serviceName": {
+          "type": "string",
+          "description": "The service name, such as `Software License`, `Cognosys`, `SendGrid`, `New-Commerce ERP Software License`, etc."
+        },
+        "productName": {
+          "type": "string",
+          "description": "The product code for an Azure service, such as `Dsv4 Series Windows VM`, `CentOS 7.6`, etc."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of lineitem, if applicable."
+        },
+        "chargeType": {
+          "type": "string",
+          "description": "The charge type of lineitem, if applicable. Such as `New`, `CycleCharge`, `Prorate fees when cancel`, etc."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of lineitem, if applicable."
+        },
+        "billableQuantity": {
+          "type": "number",
+          "format": "double",
+          "description": "The billable quantity of lineitem, if applicable."
+        },
+        "effectiveUnitPrice": {
+          "type": "number",
+          "format": "double",
+          "description": "The effective unit price of lineitem, if applicable."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The true cost (calculated) for this lineitem."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The base currency for `cost`."
+        },
+        "exchangeRate": {
+          "type": "number",
+          "format": "double",
+          "description": "The exchange rate used to convert `baseCurrency` to `targetCurrency`."
+        },
+        "targetCost": {
+          "type": "number",
+          "format": "double",
+          "description": "Converted `cost`."
+        },
+        "targetCurrency": {
+          "type": "string",
+          "description": "The currency set by `toCurrency`."
+        },
+        "timeInterval": {
+          "type": "string",
+          "description": "The time interval of lineitem, if applicable. Format is `yyyy-MM-ddThh:MM:ssZ/yyyy-mm-ddTHH:mm:ssZ` (for example 2020-09-16T00:00:00Z/2021-09-24T00:00:00Z)."
+        },
+        "billingType": {
+          "type": "string",
+          "description": "The billing type of lineitem, if applicable. Such as `MARKETPLACE`, `UPFRONT`, `Refund`, `Credit` and `OTHERS`."
+        },
+        "alternateId": {
+          "type": "string",
+          "description": "The alternate ID of lineitem, if applicable."
+        },
+        "domainName": {
+          "type": "string",
+          "description": "The domain name of lineitem, if applicable."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation of lineitem, if applicable. Such as `Cool LRS Write Operations`, `Cool LRS Data Write`, `Standard Data Transfer Out`, etc."
+        },
+        "usageType": {
+          "type": "string",
+          "description": "The usage type of lineitem, if applicable. Such as `Standard HDD Managed Disks`, `Tables`, `Blob Storage`, etc."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The instance type of lineitem, if applicable. Such as `Gateway`, `Standard_B2s`, `Standard_D4s_v3`, etc."
+        },
+        "category": {
+          "type": "string",
+          "description": "The category of lineitem, if applicable. Such as `Software License`, `Marketplace`, `RI`, `Other`, etc."
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "The subscription id."
+        },
+        "entitlementId": {
+          "type": "string",
+          "description": "The entitlement id."
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "The resource group of the lineitem, if applicable."
+        }
+      }
+    },
+    "apiazureCostAttribute": {
+      "type": "object",
+      "properties": {
+        "customerId": {
+          "type": "string"
+        },
+        "subscriptionId": {
+          "type": "string"
+        },
+        "entitlementId": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "productId": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "skuId": {
+          "type": "string"
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "domainName": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverAWSRecommendations": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "string"
+        },
+        "instanceName": {
+          "type": "string"
+        },
+        "service": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "costGroup": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "estsavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "estcost": {
+          "type": "number",
+          "format": "double"
+        },
+        "estsavingsPercentage": {
+          "type": "number",
+          "format": "double"
+        },
+        "resourceArn": {
+          "type": "string"
+        },
+        "restartNeeded": {
+          "type": "boolean"
+        },
+        "rollbackPossible": {
+          "type": "boolean"
+        },
+        "lastUpdatedAt": {
+          "type": "string"
+        },
+        "recommendationGroup": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "purchaseRIRecommendationDetails": {
+          "$ref": "#/definitions/coverPurchaseRIRecommendationDetails"
+        },
+        "savingsPlanRecommendationDetails": {
+          "$ref": "#/definitions/coverSavingsPlanRecommendationDetails"
+        },
+        "rightSizingRecommendationDetails": {
+          "$ref": "#/definitions/coverRightSizingRecommendationDetails"
+        },
+        "upgradeRecommendationDetails": {
+          "$ref": "#/definitions/coverUpgradeRecommendationDetails"
+        },
+        "migrateRecommendationDetails": {
+          "$ref": "#/definitions/coverMigrateRecommendationDetails"
+        },
+        "stopInstanceRecommendationDetails": {
+          "$ref": "#/definitions/coverStopInstanceRecommendationDetails"
+        },
+        "deleteRecommendationDetails": {
+          "$ref": "#/definitions/coverDeleteRecommendationDetails"
+        },
+        "otherRecommendationDetails": {
+          "$ref": "#/definitions/coverOtherRecommendationDetails"
+        }
+      }
+    },
+    "apicoverAccount": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "title": "account, subscription, project"
+        }
+      }
+    },
+    "apicoverAwsOptions": {
+      "type": "object",
+      "properties": {
+        "AccountName": {
+          "type": "string"
+        },
+        "PayerId": {
+          "type": "string"
+        },
+        "RoleArn": {
+          "type": "string"
+        },
+        "ExternalId": {
+          "type": "string"
+        },
+        "StackId": {
+          "type": "string"
+        },
+        "StackRegion": {
+          "type": "string"
+        },
+        "TemplateUrl": {
+          "type": "string"
+        },
+        "BucketName": {
+          "type": "string"
+        },
+        "Prefix": {
+          "type": "string"
+        },
+        "ReportName": {
+          "type": "string"
+        },
+        "registrationStatus": {
+          "$ref": "#/definitions/coverRegistrationStatus"
+        },
+        "Status": {
+          "type": "string"
+        },
+        "RegistrationMethod": {
+          "type": "string",
+          "title": "Valid values for now are: 'console', 'terraform'. default would be 'console'"
+        },
+        "templateVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverAzureOptions": {
+      "type": "object",
+      "properties": {
+        "accountName": {
+          "type": "string"
+        },
+        "azureCustomerId": {
+          "type": "string"
+        },
+        "azurePlanId": {
+          "type": "string"
+        },
+        "serviceAcct": {
+          "type": "string"
+        },
+        "partnerAcct": {
+          "type": "string"
+        },
+        "companyId": {
+          "type": "string"
+        },
+        "payerId": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverBudgetAlert": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverThreshold"
+          }
+        },
+        "channels": {
+          "$ref": "#/definitions/coverAlertChannels"
+        }
+      }
+    },
+    "apicoverCategory": {
+      "type": "object",
+      "properties": {
+        "display": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverCostCalculation": {
+      "type": "object",
+      "properties": {
+        "estCostAfterDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "estCostBeforeDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "otherDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "savingsPlanDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "estNetUnusedAmortizedCommitments": {
+          "type": "number",
+          "format": "double"
+        },
+        "reservedInstanceDiscount": {
+          "type": "number",
+          "format": "double"
+        },
+        "usageTypes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apicoverUsageTypes"
+          }
+        }
+      }
+    },
+    "apicoverCostGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "title": "cost group name"
+        }
+      }
+    },
+    "apicoverEBSDetails": {
+      "type": "object",
+      "properties": {
+        "currentEBSDetails": {
+          "$ref": "#/definitions/coverCurrentEBSDetails"
+        },
+        "upgradeEBSDetails": {
+          "$ref": "#/definitions/coverEBSRecommendationDetails"
+        }
+      }
+    },
+    "apicoverEC2Details": {
+      "type": "object",
+      "properties": {
+        "instanceType": {
+          "type": "string"
+        },
+        "tenancy": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverMemoryDBDetails": {
+      "type": "object",
+      "properties": {
+        "family": {
+          "type": "string"
+        },
+        "nodeType": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRDSDetails": {
+      "type": "object",
+      "properties": {
+        "dbEdition": {
+          "type": "string"
+        },
+        "dbEngine": {
+          "type": "string"
+        },
+        "deploymentOptions": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "instanceType": {
+          "type": "string"
+        },
+        "licenseModel": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRecommendationDetail": {
+      "type": "object",
+      "properties": {
+        "recommendation": {
+          "type": "string"
+        },
+        "recommendedResourceType": {
+          "type": "string"
+        },
+        "estimatedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "estimatedSavings": {
+          "type": "number",
+          "format": "double"
+        },
+        "region": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRedshiftDetails": {
+      "type": "object",
+      "properties": {
+        "currentGeneration": {
+          "type": "boolean"
+        },
+        "nodeType": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverResult": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverRole": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "costgroupsIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apicoverTagData": {
+      "type": "object",
+      "properties": {
+        "tagKey": {
+          "type": "string"
+        },
+        "tagValue": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apicoverUsageTypes": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "usageAmount": {
+          "type": "number",
+          "format": "double"
+        },
+        "usageType": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverUser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/coverUserRole"
+          }
+        },
+        "invitedBy": {
+          "type": "object"
+        },
+        "lastUpdated": {
+          "type": "string"
+        },
+        "createdOn": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        },
+        "activated": {
+          "type": "boolean"
+        },
+        "colorTheme": {
+          "type": "string"
+        }
+      }
+    },
+    "apicoverUtilizationData": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    "apigcpCost": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string",
+          "title": "account data"
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group id the account is associated with during the query."
+        },
+        "date": {
+          "type": "string",
+          "description": "For daily data, format is `yyyy-mm-dd`; for monthly, `yyyy-mm`."
+        },
+        "invoiceMonth": {
+          "type": "string",
+          "description": "The invoice.month of the lineitem, if applicable."
+        },
+        "service": {
+          "type": "string",
+          "description": "The service.Description of the lineitem, if applicable."
+        },
+        "sku": {
+          "type": "string",
+          "description": "The sku.Description of the lineitem, if applicable."
+        },
+        "region": {
+          "type": "string",
+          "description": "The location.region of the lineitem, if applicable."
+        },
+        "zone": {
+          "type": "string",
+          "description": "The location.zone of the lineitem, if applicable."
+        },
+        "creditsType": {
+          "type": "string",
+          "description": "The credits.type of the lineitem, if applicable."
+        },
+        "creditsName": {
+          "type": "string",
+          "description": "The credits.name of the lineitem, if applicable."
+        },
+        "usageUnit": {
+          "type": "string",
+          "description": "The usage.pricing_unit of the lineitem, if applicable."
+        },
+        "usageAmount": {
+          "type": "number",
+          "format": "double",
+          "description": "The usage.amount_in_pricing_units of the lineitem, if applicable."
+        },
+        "baseCurrency": {
+          "type": "string",
+          "description": "The currency of the lineitem, if applicable."
+        },
+        "cost": {
+          "type": "number",
+          "format": "double",
+          "description": "The cost of the lineitem, if applicable."
+        }
+      },
+      "description": "see gcp billing data schema details:[https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables]",
+      "title": "Cost for Api Response"
+    },
+    "apilusterLabel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The label id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The label name."
+        },
+        "color": {
+          "type": "string",
+          "description": "The label color.\nformat: HEX color code ( #FF0000 )."
+        },
+        "description": {
+          "type": "string",
+          "description": "The label description."
+        },
+        "createdAt": {
+          "type": "string",
+          "title": "The label createdAt.\n\"created_at\": \"2023-10-27T10:00:00Z\"",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "title": "The label updatedAt.\n\"updated_at\": \"2023-10-27T10:00:00Z\"",
+          "readOnly": true
+        }
+      },
+      "title": "The message defines the label"
+    },
+    "apirippleAccessGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "billingGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "AccessGroup resource definition."
+    },
+    "apirippleOrg": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The unique name (or id) of the organization."
+        },
+        "email": {
+          "type": "string",
+          "description": "The registered email of the organization."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The metadata (key/value pair) of the organization. If hierarchy is supported, it will be\nseparated by '/', such as 'metakey/subkey=value'. See https://alphauslabs.github.io/blueapi/\nfor the list of supported attributes."
+        }
+      },
+      "description": "Org resource definition."
+    },
+    "apiripplev1InvoiceServiceDiscounts": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The invoice service discounts id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The invoice service discount name.\nmust be 1-60 characters long."
+        },
+        "description": {
+          "type": "string",
+          "description": "The invoice service discount description.\nMaximum 150 characters long."
+        },
+        "setting": {
+          "$ref": "#/definitions/v1InvoiceServiceDiscountsSetting",
+          "description": "The invoice service discount setting."
+        },
+        "created": {
+          "type": "string",
+          "description": "Timestamp associated with the created.",
+          "readOnly": true
+        },
+        "updated": {
+          "type": "string",
+          "description": "Timestamp associated with the updated.",
+          "readOnly": true
+        }
+      },
+      "description": "InvoiceServiceDiscounts resource definition."
+    },
+    "apiwaveBudget": {
       "type": "object",
       "properties": {
         "id": {
@@ -30378,7 +30378,7 @@
       },
       "description": "Budget resource definition."
     },
-    "apiWaveBudgetAlert": {
+    "apiwaveBudgetAlert": {
       "type": "object",
       "properties": {
         "id": {
@@ -30390,7 +30390,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiWaveNotification"
+            "$ref": "#/definitions/apiwaveNotification"
           },
           "description": "notification setting."
         },
@@ -30398,14 +30398,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiWaveBudget"
+            "$ref": "#/definitions/apiwaveBudget"
           },
           "description": "budget setting."
         }
       },
       "description": "Budget resource definition."
     },
-    "apiWaveNotification": {
+    "apiwaveNotification": {
       "type": "object",
       "properties": {
         "id": {
@@ -30507,7 +30507,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiAwsChartData"
+            "$ref": "#/definitions/apiawsChartData"
           }
         }
       }
@@ -31183,7 +31183,7 @@
     "azurecspAzureCSPRecommendations": {
       "type": "object"
     },
-    "billingV1AccessGroup": {
+    "billingv1AccessGroup": {
       "type": "object",
       "properties": {
         "accessGroupId": {
@@ -31202,14 +31202,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/billingV1BillingGroup"
+            "$ref": "#/definitions/billingv1BillingGroup"
           },
           "description": "A list of billing groups contained in the access group."
         }
       },
       "description": "Defines the fields associated with a Wave access group."
     },
-    "billingV1AwsOptions": {
+    "billingv1AwsOptions": {
       "type": "object",
       "properties": {
         "useProFormaCur": {
@@ -31221,7 +31221,7 @@
         }
       }
     },
-    "billingV1AzureOptions": {
+    "billingv1AzureOptions": {
       "type": "object",
       "properties": {
         "resourceGroup": {
@@ -31239,7 +31239,7 @@
       },
       "title": "Optional. Azure-specific options"
     },
-    "billingV1BillingGroup": {
+    "billingv1BillingGroup": {
       "type": "object",
       "properties": {
         "billingInternalId": {
@@ -31278,7 +31278,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "title": "List of all accounts"
         },
@@ -31299,12 +31299,12 @@
           "title": "List of all additionalItems"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingV1AwsOptions",
+          "$ref": "#/definitions/billingv1AwsOptions",
           "title": "AWS-specific options"
         }
       }
     },
-    "billingV1InvoiceSettings": {
+    "billingv1InvoiceSettings": {
       "type": "object",
       "properties": {
         "invoiceNo": {
@@ -31391,7 +31391,7 @@
         }
       }
     },
-    "billingV1Tag": {
+    "billingv1Tag": {
       "type": "object",
       "properties": {
         "key": {
@@ -31410,7 +31410,7 @@
       },
       "title": "Individual tag definition for AddTagsToBillingGroup"
     },
-    "billingV1TagData": {
+    "billingv1TagData": {
       "type": "object",
       "properties": {
         "customerId": {
@@ -31432,7 +31432,7 @@
       },
       "title": "Response for tag request"
     },
-    "blueapiApiAccount": {
+    "blueapiapiAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31465,7 +31465,7 @@
         }
       }
     },
-    "blueapiApiBudget": {
+    "blueapiapiBudget": {
       "type": "object",
       "properties": {
         "id": {
@@ -31484,7 +31484,7 @@
         }
       }
     },
-    "blueapiApiChartData": {
+    "blueapiapiChartData": {
       "type": "object",
       "properties": {
         "date": {
@@ -31511,7 +31511,7 @@
         }
       }
     },
-    "blueapiApiFeeDetails": {
+    "blueapiapiFeeDetails": {
       "type": "object",
       "properties": {
         "name": {
@@ -31527,7 +31527,7 @@
       },
       "description": "FeeDetails resource definition."
     },
-    "blueapiApiInvoiceSettings": {
+    "blueapiapiInvoiceSettings": {
       "type": "object",
       "properties": {
         "address": {
@@ -31580,7 +31580,7 @@
       },
       "description": "InvoiceSettings resource definition."
     },
-    "blueapiApiNotification": {
+    "blueapiapiNotification": {
       "type": "object",
       "properties": {
         "id": {
@@ -31599,11 +31599,11 @@
           "type": "boolean"
         },
         "account": {
-          "$ref": "#/definitions/blueapiApiNotificationAccount"
+          "$ref": "#/definitions/blueapiapiNotificationAccount"
         }
       }
     },
-    "blueapiApiNotificationAccount": {
+    "blueapiapiNotificationAccount": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31614,7 +31614,7 @@
         }
       }
     },
-    "blueapiApiRole": {
+    "blueapiapiRole": {
       "type": "object",
       "properties": {
         "name": {
@@ -31638,7 +31638,7 @@
         }
       }
     },
-    "blueapiApiUser": {
+    "blueapiapiUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -31658,7 +31658,7 @@
         }
       }
     },
-    "blueapiApiUtilizationData": {
+    "blueapiapiUtilizationData": {
       "type": "object",
       "properties": {
         "id": {
@@ -31668,12 +31668,12 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiChartData"
+            "$ref": "#/definitions/blueapiapiChartData"
           }
         }
       }
     },
-    "blueapiBillingV1InvoiceServiceDiscounts": {
+    "blueapibillingv1InvoiceServiceDiscounts": {
       "type": "object",
       "properties": {
         "id": {
@@ -31699,7 +31699,7 @@
       },
       "description": "Streaming response message for the InvoiceServiceDiscounts rpc."
     },
-    "blueapiBillingV1ListExchangeRatesResponse": {
+    "blueapibillingv1ListExchangeRatesResponse": {
       "type": "object",
       "properties": {
         "month": {
@@ -31725,22 +31725,22 @@
       },
       "description": "Response message for the ListExchangeRates rpc."
     },
-    "blueapiCostV1CostItem": {
+    "blueapicostv1CostItem": {
       "type": "object",
       "properties": {
         "aws": {
-          "$ref": "#/definitions/apiAwsCost"
+          "$ref": "#/definitions/apiawsCost"
         },
         "gcp": {
-          "$ref": "#/definitions/apiGcpCost"
+          "$ref": "#/definitions/apigcpCost"
         },
         "azure": {
-          "$ref": "#/definitions/apiAzureCost"
+          "$ref": "#/definitions/apiazureCost"
         }
       },
       "description": "Response message wrapper for cloud costs."
     },
-    "blueapiCoverV1CostItem": {
+    "blueapicoverv1CostItem": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -31823,15 +31823,15 @@
       },
       "description": "Response message wrapper for cloud costs."
     },
-    "blueapiCoverV1GetUserResponse": {
+    "blueapicoverv1GetUserResponse": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiCoverUser"
+          "$ref": "#/definitions/apicoverUser"
         }
       }
     },
-    "blueapiCoverV1ListExchangeRatesResponse": {
+    "blueapicoverv1ListExchangeRatesResponse": {
       "type": "object",
       "properties": {
         "orgId": {
@@ -31847,7 +31847,7 @@
       },
       "title": "Response message for ListExchangeRates"
     },
-    "blueapiCoverV1Resource": {
+    "blueapicoverv1Resource": {
       "type": "object",
       "properties": {
         "date": {
@@ -31893,7 +31893,7 @@
         }
       }
     },
-    "blueapiFlowV1DailyUtilization": {
+    "blueapiflowv1DailyUtilization": {
       "type": "object",
       "properties": {
         "currentDate": {
@@ -31908,7 +31908,7 @@
       },
       "description": "Daily utilization data for a specific date range."
     },
-    "blueapiFlowV1GetInfoResponse": {
+    "blueapiflowv1GetInfoResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -31917,7 +31917,7 @@
       },
       "description": "Response message for the Flow.GetInfo rpc."
     },
-    "blueapiGcV1Resource": {
+    "blueapigcv1Resource": {
       "type": "object",
       "properties": {
         "id": {
@@ -32057,7 +32057,7 @@
         }
       }
     },
-    "blueapiOrgV1CreateOrgRequest": {
+    "blueapiorgv1CreateOrgRequest": {
       "type": "object",
       "properties": {
         "email": {
@@ -32103,11 +32103,11 @@
       },
       "description": "Request message for the Organization.CreateOrg rpc."
     },
-    "blueapiOrgV1CreateOrgResponse": {
+    "blueapiorgv1CreateOrgResponse": {
       "type": "object",
       "properties": {
         "org": {
-          "$ref": "#/definitions/apiRippleOrg"
+          "$ref": "#/definitions/apirippleOrg"
         },
         "password": {
           "type": "string"
@@ -32115,7 +32115,7 @@
       },
       "description": "Response message for the Organization.CreateOrg rpc."
     },
-    "blueapiPricingV1GetInfoResponse": {
+    "blueapipricingv1GetInfoResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -32124,7 +32124,7 @@
       },
       "description": "Response message for the Pricing.GetInfo rpc."
     },
-    "blueapiPrismV1TestResponse": {
+    "blueapiprismv1TestResponse": {
       "type": "object",
       "properties": {
         "response": {
@@ -32132,7 +32132,7 @@
         }
       }
     },
-    "blueapiVortexV1CreateOrgRequest": {
+    "blueapivortexv1CreateOrgRequest": {
       "type": "object",
       "properties": {
         "name": {
@@ -32143,7 +32143,7 @@
         }
       }
     },
-    "blueapiVortexV1CreateOrgResponse": {
+    "blueapivortexv1CreateOrgResponse": {
       "type": "object",
       "properties": {
         "orgId": {
@@ -32157,7 +32157,7 @@
         }
       }
     },
-    "blueapiVortexV1GetUserResponse": {
+    "blueapivortexv1GetUserResponse": {
       "type": "object",
       "properties": {
         "id": {
@@ -32174,7 +32174,7 @@
         }
       }
     },
-    "blueapiVortexV1TestResponse": {
+    "blueapivortexv1TestResponse": {
       "type": "object",
       "properties": {
         "message": {
@@ -32183,7 +32183,7 @@
       },
       "title": "Test only"
     },
-    "costV1CostAttribute": {
+    "costv1CostAttribute": {
       "type": "object",
       "properties": {
         "vendor": {
@@ -32200,7 +32200,7 @@
         }
       }
     },
-    "costV1ListCostFilters": {
+    "costv1ListCostFilters": {
       "type": "object",
       "properties": {
         "filterId": {
@@ -32485,7 +32485,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverBudgetAlert"
+            "$ref": "#/definitions/apicoverBudgetAlert"
           },
           "title": "threshold(s) and its respective channel(s) to alert"
         },
@@ -32642,7 +32642,7 @@
           "type": "string"
         },
         "costgroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "startDate": {
           "type": "string"
@@ -32909,7 +32909,7 @@
           "format": "double"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -32948,35 +32948,35 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "eC2DiskUtilization": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "eC2MemoryUtilization": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "networkTrafficData": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "otherDetails": {
           "$ref": "#/definitions/CurrentEC2DetailsOtherDetails"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33070,7 +33070,7 @@
           "format": "double"
         },
         "EstcostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33102,7 +33102,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33800,10 +33800,10 @@
           "$ref": "#/definitions/coverEC2UpgadeDetails"
         },
         "currentCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         },
         "estCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -33892,7 +33892,7 @@
       "type": "object",
       "properties": {
         "ec2Options": {
-          "$ref": "#/definitions/apiCoverEC2Details"
+          "$ref": "#/definitions/apicoverEC2Details"
         },
         "elasticCacheOptions": {
           "$ref": "#/definitions/coverElasticCacheDetails"
@@ -33901,13 +33901,13 @@
           "$ref": "#/definitions/coverESDetails"
         },
         "rdsOptions": {
-          "$ref": "#/definitions/apiCoverRDSDetails"
+          "$ref": "#/definitions/apicoverRDSDetails"
         },
         "redshiftOptions": {
-          "$ref": "#/definitions/apiCoverRedshiftDetails"
+          "$ref": "#/definitions/apicoverRedshiftDetails"
         },
         "memoryDbOptions": {
-          "$ref": "#/definitions/apiCoverMemoryDBDetails"
+          "$ref": "#/definitions/apicoverMemoryDBDetails"
         },
         "recommendedNormalizedUnits": {
           "type": "integer",
@@ -33966,7 +33966,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         }
       }
@@ -33978,7 +33978,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -34012,7 +34012,7 @@
           "type": "string"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -34131,7 +34131,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverRecommendationDetail"
+            "$ref": "#/definitions/apicoverRecommendationDetail"
           }
         },
         "currentCost": {
@@ -34182,7 +34182,7 @@
           "format": "int32"
         },
         "costCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -34428,7 +34428,7 @@
           "$ref": "#/definitions/coverLambdaRightSizingRecommendationDetails"
         },
         "ebsRightSizingRecommendationDetails": {
-          "$ref": "#/definitions/apiCoverEBSDetails"
+          "$ref": "#/definitions/apicoverEBSDetails"
         },
         "ecsRightSizingRecommendationDetails": {
           "$ref": "#/definitions/coverEcsRightSizingRecommendationDetails"
@@ -34845,14 +34845,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         },
         "netWorkIO": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUtilizationData"
+            "$ref": "#/definitions/apicoverUtilizationData"
           }
         }
       }
@@ -35038,10 +35038,10 @@
           "$ref": "#/definitions/coverEC2UpgadeDetails"
         },
         "currentCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         },
         "estimatedCostCalculation": {
-          "$ref": "#/definitions/apiCoverCostCalculation"
+          "$ref": "#/definitions/apicoverCostCalculation"
         }
       }
     },
@@ -35052,7 +35052,7 @@
           "$ref": "#/definitions/coverUpgradeEC2Details"
         },
         "upgradeEBSDetails": {
-          "$ref": "#/definitions/apiCoverEBSDetails"
+          "$ref": "#/definitions/apicoverEBSDetails"
         },
         "upgradeRDSDetails": {
           "$ref": "#/definitions/coverRDSUpgradeDetails"
@@ -35183,81 +35183,6 @@
           }
         }
       }
-    },
-    "coverV1FeeDetails": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "orgId": {
-          "type": "string"
-        },
-        "vendor": {
-          "type": "string"
-        },
-        "account": {
-          "type": "string"
-        },
-        "month": {
-          "type": "string"
-        },
-        "lineType": {
-          "type": "string"
-        },
-        "feeType": {
-          "type": "string"
-        },
-        "productCode": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "started": {
-          "type": "string"
-        },
-        "timeInterval": {
-          "type": "string"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "currency": {
-          "type": "string"
-        },
-        "splitStatus": {
-          "type": "string"
-        },
-        "isAllocated": {
-          "type": "boolean"
-        },
-        "isApplied": {
-          "type": "boolean"
-        },
-        "unblendedCost": {
-          "type": "number",
-          "format": "double"
-        },
-        "sourceFee": {
-          "type": "string"
-        },
-        "lastUpdate": {
-          "type": "string"
-        }
-      },
-      "description": "Response message for GetFeeDetails, CreateFeeReallocation rpc."
-    },
-    "coverV1Status": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "IN_PROGRESS",
-        "SUCCESS",
-        "FAILED"
-      ],
-      "default": "PENDING",
-      "title": "Status of upload file"
     },
     "coverViewData": {
       "type": "object",
@@ -35394,7 +35319,82 @@
         }
       }
     },
-    "flowV1SavingsPlanDetailsPurchase": {
+    "coverv1FeeDetails": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "orgId": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "account": {
+          "type": "string"
+        },
+        "month": {
+          "type": "string"
+        },
+        "lineType": {
+          "type": "string"
+        },
+        "feeType": {
+          "type": "string"
+        },
+        "productCode": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "started": {
+          "type": "string"
+        },
+        "timeInterval": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "currency": {
+          "type": "string"
+        },
+        "splitStatus": {
+          "type": "string"
+        },
+        "isAllocated": {
+          "type": "boolean"
+        },
+        "isApplied": {
+          "type": "boolean"
+        },
+        "unblendedCost": {
+          "type": "number",
+          "format": "double"
+        },
+        "sourceFee": {
+          "type": "string"
+        },
+        "lastUpdate": {
+          "type": "string"
+        }
+      },
+      "description": "Response message for GetFeeDetails, CreateFeeReallocation rpc."
+    },
+    "coverv1Status": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "FAILED"
+      ],
+      "default": "PENDING",
+      "title": "Status of upload file"
+    },
+    "flowv1SavingsPlanDetailsPurchase": {
       "type": "object",
       "properties": {
         "payerId": {
@@ -35444,7 +35444,7 @@
       },
       "title": "Savings plan details to be purchased"
     },
-    "flowV1SavingsPlanRecommendation": {
+    "flowv1SavingsPlanRecommendation": {
       "type": "object",
       "properties": {
         "payerId": {
@@ -35494,20 +35494,6 @@
       },
       "title": "Savings plan recommendation details"
     },
-    "gcV1Org": {
-      "type": "object",
-      "properties": {
-        "orgId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        }
-      }
-    },
     "gcpGCPRecommendations": {
       "type": "object",
       "properties": {
@@ -35540,7 +35526,21 @@
         }
       }
     },
-    "googleRpcStatus": {
+    "gcv1Org": {
+      "type": "object",
+      "properties": {
+        "orgId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "googlerpcStatus": {
       "type": "object",
       "properties": {
         "code": {
@@ -35849,7 +35849,7 @@
           "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable."
         },
         "error": {
-          "$ref": "#/definitions/googleRpcStatus",
+          "$ref": "#/definitions/googlerpcStatus",
           "description": "The error result of the operation in case of failure or cancellation."
         },
         "response": {
@@ -35858,23 +35858,6 @@
         }
       },
       "description": "This resource represents a long-running operation that is the result of a\nnetwork API call."
-    },
-    "recommendationAwsAWSRecommendations": {
-      "type": "object",
-      "properties": {
-        "costExplorerRecommendations": {
-          "$ref": "#/definitions/awsCostExplorerRecommendations"
-        },
-        "costOptimizationHubRecommendations": {
-          "$ref": "#/definitions/awsCostOptimizationHubRecommendations"
-        },
-        "trustedAdvisorRecommendations": {
-          "$ref": "#/definitions/awsTrustedAdvisorRecommendations"
-        },
-        "resourceArn": {
-          "type": "string"
-        }
-      }
     },
     "recommendationOCTOGeneratedRecommendations": {
       "type": "object",
@@ -35894,7 +35877,7 @@
       "type": "object",
       "properties": {
         "awsRecommendations": {
-          "$ref": "#/definitions/recommendationAwsAWSRecommendations"
+          "$ref": "#/definitions/recommendationawsAWSRecommendations"
         },
         "gcpRecommendations": {
           "$ref": "#/definitions/gcpGCPRecommendations"
@@ -35973,6 +35956,23 @@
         }
       }
     },
+    "recommendationawsAWSRecommendations": {
+      "type": "object",
+      "properties": {
+        "costExplorerRecommendations": {
+          "$ref": "#/definitions/awsCostExplorerRecommendations"
+        },
+        "costOptimizationHubRecommendations": {
+          "$ref": "#/definitions/awsCostOptimizationHubRecommendations"
+        },
+        "trustedAdvisorRecommendations": {
+          "$ref": "#/definitions/awsTrustedAdvisorRecommendations"
+        },
+        "resourceArn": {
+          "type": "string"
+        }
+      }
+    },
     "rippleAssigned": {
       "type": "object",
       "properties": {
@@ -36012,7 +36012,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "A list of accounts."
         },
@@ -36340,7 +36340,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "List of all members under this payer."
         }
@@ -36961,7 +36961,7 @@
           "description": "Account id."
         },
         "serviceDiscounts": {
-          "$ref": "#/definitions/apiRippleV1InvoiceServiceDiscounts",
+          "$ref": "#/definitions/apiripplev1InvoiceServiceDiscounts",
           "description": "service discount infomation."
         }
       },
@@ -38597,7 +38597,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Lsit of accountId."
         },
@@ -39844,10 +39844,10 @@
       "type": "object",
       "properties": {
         "aws": {
-          "$ref": "#/definitions/apiAwsCostAttribute"
+          "$ref": "#/definitions/apiawsCostAttribute"
         },
         "azure": {
-          "$ref": "#/definitions/apiAzureCostAttribute"
+          "$ref": "#/definitions/apiazureCostAttribute"
         }
       },
       "description": "Response message for the Cost.ReadCostAttributes rpc."
@@ -40282,7 +40282,7 @@
           "title": "Invoice settings"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingV1AwsOptions",
+          "$ref": "#/definitions/billingv1AwsOptions",
           "title": "Optional. AWS-specific options"
         },
         "city": {
@@ -40328,7 +40328,7 @@
           "title": "Optional. Custom fields to add to the billing group"
         },
         "azureOptions": {
-          "$ref": "#/definitions/billingV1AzureOptions"
+          "$ref": "#/definitions/billingv1AzureOptions"
         }
       },
       "description": "Request message for the CreateBillingGroupMerged rpc."
@@ -40397,7 +40397,7 @@
           "title": "Invoice settings"
         },
         "awsOptions": {
-          "$ref": "#/definitions/billingV1AwsOptions",
+          "$ref": "#/definitions/billingv1AwsOptions",
           "title": "Optional. AWS-specific options"
         },
         "city": {
@@ -40704,7 +40704,7 @@
           "title": "Optional. Description of the forecast"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup",
+          "$ref": "#/definitions/apicoverCostGroup",
           "title": "Required. Cost Group Id and Name"
         },
         "pastActualCostRange": {
@@ -40740,7 +40740,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -41260,7 +41260,7 @@
           "title": "Required"
         },
         "account": {
-          "$ref": "#/definitions/adminV1NotificationAccount",
+          "$ref": "#/definitions/adminv1NotificationAccount",
           "description": "Optional. only available Wave(Pro)."
         }
       },
@@ -41992,11 +41992,11 @@
           "title": "GCP Options"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apiCoverAzureOptions",
+          "$ref": "#/definitions/apicoverAzureOptions",
           "title": "Azure Options"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apiCoverAwsOptions"
+          "$ref": "#/definitions/apicoverAwsOptions"
         },
         "accountType": {
           "type": "string",
@@ -42602,6 +42602,10 @@
         "endTime": {
           "type": "string",
           "description": "Required. The UTC date to end data from. If not set, the first day of the current year will be used. Format: `yyyymmdd`."
+        },
+        "product": {
+          "type": "string",
+          "description": "Optional. Valid values are 'ripple' and 'wavepro' for now. If empty default is 'ripple'."
         }
       },
       "description": "Request message for the ExportAuditLogs rpc."
@@ -42878,7 +42882,7 @@
       "type": "object",
       "properties": {
         "accessGroup": {
-          "$ref": "#/definitions/billingV1AccessGroup"
+          "$ref": "#/definitions/billingv1AccessGroup"
         }
       },
       "description": "Response message for the Billing.GetAccessGroup rpc."
@@ -42916,7 +42920,7 @@
       "type": "object",
       "properties": {
         "data": {
-          "$ref": "#/definitions/blueapiApiBudget"
+          "$ref": "#/definitions/blueapiapiBudget"
         }
       },
       "title": "Response message for GetAccountBudget"
@@ -42987,7 +42991,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverTagData"
+            "$ref": "#/definitions/apicoverTagData"
           }
         }
       },
@@ -43187,7 +43191,7 @@
       "type": "object",
       "properties": {
         "billingGroup": {
-          "$ref": "#/definitions/billingV1BillingGroup"
+          "$ref": "#/definitions/billingv1BillingGroup"
         }
       },
       "description": "Response message for the Billing.GetBillingGroup rpc."
@@ -43273,7 +43277,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverCategory"
+            "$ref": "#/definitions/apicoverCategory"
           }
         }
       }
@@ -43325,7 +43329,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Optional. accounts that applied to the CustomizedBillingService　config."
         }
@@ -43425,7 +43429,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/costV1CostAttribute"
+            "$ref": "#/definitions/costv1CostAttribute"
           },
           "description": "The cost attributes."
         }
@@ -43471,7 +43475,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -43602,14 +43606,14 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverResult"
+            "$ref": "#/definitions/apicoverResult"
           }
         },
         "tagData": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverTagData"
+            "$ref": "#/definitions/apicoverTagData"
           }
         }
       },
@@ -44109,7 +44113,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiAccount"
+            "$ref": "#/definitions/blueapiapiAccount"
           },
           "description": "Optional. accounts that applied to the CustomizedBillingService　config."
         }
@@ -44501,7 +44505,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverRole"
+            "$ref": "#/definitions/apicoverRole"
           }
         }
       }
@@ -44824,7 +44828,7 @@
       "type": "object",
       "properties": {
         "recommendationData": {
-          "$ref": "#/definitions/apiCoverAWSRecommendations"
+          "$ref": "#/definitions/apicoverAWSRecommendations"
         }
       }
     },
@@ -45073,14 +45077,14 @@
       "type": "object",
       "properties": {
         "recommendation": {
-          "$ref": "#/definitions/flowV1SavingsPlanRecommendation",
+          "$ref": "#/definitions/flowv1SavingsPlanRecommendation",
           "title": "Recommendation details"
         },
         "purchases": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/flowV1SavingsPlanDetailsPurchase"
+            "$ref": "#/definitions/flowv1SavingsPlanDetailsPurchase"
           },
           "title": "List of purchase items"
         },
@@ -45193,7 +45197,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverTagData"
+            "$ref": "#/definitions/apicoverTagData"
           }
         }
       },
@@ -45317,7 +45321,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiUtilizationData"
+            "$ref": "#/definitions/blueapiapiUtilizationData"
           }
         }
       },
@@ -45462,7 +45466,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverUser"
+            "$ref": "#/definitions/apicoverUser"
           }
         }
       }
@@ -45917,7 +45921,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/costV1ListCostFilters"
+            "$ref": "#/definitions/costv1ListCostFilters"
           }
         }
       },
@@ -46077,21 +46081,21 @@
         "createdVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingV1InvoiceSettings"
+            "$ref": "#/definitions/billingv1InvoiceSettings"
           },
           "title": "setting used in invoice creation"
         },
         "savedVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingV1InvoiceSettings"
+            "$ref": "#/definitions/billingv1InvoiceSettings"
           },
           "title": "saved invoice setting for the month"
         },
         "defaultVendorInvoiceSetting": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/billingV1InvoiceSettings"
+            "$ref": "#/definitions/billingv1InvoiceSettings"
           },
           "title": "billinggroup's default invoice setting"
         },
@@ -46200,7 +46204,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiNotification"
+            "$ref": "#/definitions/blueapiapiNotification"
           }
         }
       },
@@ -46432,7 +46436,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiGcV1Resource"
+            "$ref": "#/definitions/blueapigcv1Resource"
           }
         }
       }
@@ -46444,7 +46448,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiApiRole"
+            "$ref": "#/definitions/blueapiapiRole"
           }
         }
       },
@@ -48081,11 +48085,11 @@
           "title": "GCP Options. Specific for GCP"
         },
         "azureOptions": {
-          "$ref": "#/definitions/apiCoverAzureOptions",
+          "$ref": "#/definitions/apicoverAzureOptions",
           "title": "Azure Options. Specific for Azure"
         },
         "awsOptions": {
-          "$ref": "#/definitions/apiCoverAwsOptions",
+          "$ref": "#/definitions/apicoverAwsOptions",
           "title": "Aws Options. Specific for Aws"
         }
       },
@@ -48204,7 +48208,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiCoverUser"
+          "$ref": "#/definitions/apicoverUser"
         }
       }
     },
@@ -48630,7 +48634,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCoverAccount"
+            "$ref": "#/definitions/apicoverAccount"
           }
         }
       }
@@ -49540,7 +49544,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/billingV1Tag"
+            "$ref": "#/definitions/billingv1Tag"
           },
           "title": "Tags associated with this customer"
         }
@@ -49884,7 +49888,7 @@
           "type": "string"
         },
         "costGroup": {
-          "$ref": "#/definitions/apiCoverCostGroup"
+          "$ref": "#/definitions/apicoverCostGroup"
         },
         "pastActualCostRange": {
           "type": "string",
@@ -50369,7 +50373,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiCoverUser"
+          "$ref": "#/definitions/apicoverUser"
         }
       }
     },
@@ -50491,7 +50495,7 @@
           "title": "File name"
         },
         "status": {
-          "$ref": "#/definitions/coverV1Status",
+          "$ref": "#/definitions/coverv1Status",
           "title": "Status"
         }
       },
@@ -50585,7 +50589,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/blueapiFlowV1DailyUtilization"
+            "$ref": "#/definitions/blueapiflowv1DailyUtilization"
           },
           "title": "Array of daily utilization data for this Savings Plan"
         }


### PR DESCRIPTION
## Summary
- Add optional `product` field to `ExportAuditLogsRequest` in `admin/v1/admin.proto`
- Valid values: `ripple` and `wavepro` (defaults to `ripple` when empty)
- Regenerated `openapiv2/apidocs.swagger.json` via `./build.sh`

